### PR TITLE
Convert XSE scripts to CFRU injected ones

### DIFF
--- a/assembly/debug/debug_mode.s
+++ b/assembly/debug/debug_mode.s
@@ -7,14 +7,14 @@
 
 .global EventScript_DebugMode_Main
 EventScript_DebugMode_Main:
-	givepokemon SPECIES_BULBASAUR 0x32 0x0 0x0 0x0 0x0 @lv 50 Bulbasaur
-	givepokemon SPECIES_CHARMANDER 0x32 0x0 0x0 0x0 0x0 @lv 50 Charmander
-	givepokemon SPECIES_SQUIRTLE 0x32 0x0 0x0 0x0 0x0 @lv 50 Squirtle
-	givepokemon SPECIES_GROOKEY 0x32 0x0 0x0 0x0 0x0 @lv 50 Grookey
-	givepokemon SPECIES_SCORBUNNY 0x32 0x0 0x0 0x0 0x0 @lv 50 Scorbunny
-	givepokemon SPECIES_SOBBLE 0x32 0x0 0x0 0x0 0x0 @lv 50 Sobble
+	givepokemon SPECIES_BULBASAUR 0x32 0x0 0x0 0x0 0x0 @ lv 50 Bulbasaur
+	givepokemon SPECIES_CHARMANDER 0x32 0x0 0x0 0x0 0x0 @ lv 50 Charmander
+	givepokemon SPECIES_SQUIRTLE 0x32 0x0 0x0 0x0 0x0 @ lv 50 Squirtle
+	givepokemon SPECIES_GROOKEY 0x32 0x0 0x0 0x0 0x0 @ lv 50 Grookey
+	givepokemon SPECIES_SCORBUNNY 0x32 0x0 0x0 0x0 0x0 @ lv 50 Scorbunny
+	givepokemon SPECIES_SOBBLE 0x32 0x0 0x0 0x0 0x0 @ lv 50 Sobble
 
-	@mark all pokemon in the dex as seen
+	@ mark all pokemon in the dex as seen
 	setvar 0x8004 SPECIES_BIDOOF
 	special 0x163
 
@@ -1374,7 +1374,7 @@ EventScript_DebugMode_Main:
 	@ Give the player certain key items, like mega/primal reversion/ultra burst items
 	setflag 0x828 @ Enable Pokemon Menu
 	setflag 0x829 @ Enable Pokedex Menu
-	giveitem ITEM_POKE_BALL 0x32 MSG_FIND @Give 50 pokeballs
-	giveitem ITEM_RARE_CANDY 0x1E MSG_FIND @Give 30 rare candies
+	giveitem ITEM_POKE_BALL 0x32 MSG_FIND @ Give 50 pokeballs
+	giveitem ITEM_RARE_CANDY 0x1E MSG_FIND @ Give 30 rare candies
 	additem ITEM_TOWN_MAP 0x1 @ Give town map
 	@ giveitem2 0x169 0x1 0x13E @ Give town map with fanfare (base game uses both)

--- a/assembly/debug/debug_mode.s
+++ b/assembly/debug/debug_mode.s
@@ -1,0 +1,1380 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+.include "../asm_defines.s"
+
+.global EventScript_DebugMode_Main
+EventScript_DebugMode_Main:
+	givepokemon SPECIES_BULBASAUR 0x32 0x0 0x0 0x0 0x0 @lv 50 Bulbasaur
+	givepokemon SPECIES_CHARMANDER 0x32 0x0 0x0 0x0 0x0 @lv 50 Charmander
+	givepokemon SPECIES_SQUIRTLE 0x32 0x0 0x0 0x0 0x0 @lv 50 Squirtle
+	givepokemon SPECIES_GROOKEY 0x32 0x0 0x0 0x0 0x0 @lv 50 Grookey
+	givepokemon SPECIES_SCORBUNNY 0x32 0x0 0x0 0x0 0x0 @lv 50 Scorbunny
+	givepokemon SPECIES_SOBBLE 0x32 0x0 0x0 0x0 0x0 @lv 50 Sobble
+
+	@mark all pokemon in the dex as seen
+	setvar 0x8004 SPECIES_BIDOOF
+	special 0x163
+
+	setvar 0x8004 SPECIES_BIBAREL
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROOKIDEE
+	special 0x163
+
+	setvar 0x8004 SPECIES_CORVISQUIRE
+	special 0x163
+
+	setvar 0x8004 SPECIES_CORVIKNIGHT
+	special 0x163
+
+	setvar 0x8004 SPECIES_SUNKERN
+	special 0x163
+
+	setvar 0x8004 SPECIES_SUNFLORA
+	special 0x163
+
+	setvar 0x8004 SPECIES_YAMPER
+	special 0x163
+
+	setvar 0x8004 SPECIES_BOLTUND
+	special 0x163
+
+	setvar 0x8004 SPECIES_BUDEW
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROSELIA
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROSERADE
+	special 0x163
+
+	setvar 0x8004 SPECIES_GRUBBIN
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHARJABUG
+	special 0x163
+
+	setvar 0x8004 SPECIES_VIKAVOLT
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROCKRUFF
+	special 0x163
+
+	setvar 0x8004 SPECIES_LYCANROC
+	special 0x163
+
+	setvar 0x8004 SPECIES_LYCANROC_N
+	special 0x163
+
+	setvar 0x8004 SPECIES_LYCANROC_DUSK
+	special 0x163
+
+	setvar 0x8004 SPECIES_NICKIT
+	special 0x163
+
+	setvar 0x8004 SPECIES_THIEVUL
+	special 0x163
+
+	setvar 0x8004 SPECIES_NIDORAN_M
+	special 0x163
+
+	setvar 0x8004 SPECIES_NIDORINO
+	special 0x163
+
+	setvar 0x8004 SPECIES_NIDOKING
+	special 0x163
+
+	setvar 0x8004 SPECIES_BLIPBUG
+	special 0x163
+
+	setvar 0x8004 SPECIES_DOTTLER
+	special 0x163
+
+	setvar 0x8004 SPECIES_ORBEETLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_PIKIPEK
+	special 0x163
+
+	setvar 0x8004 SPECIES_TRUMBEAK
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOUCANNON
+	special 0x163
+
+	setvar 0x8004 SPECIES_MORELULL
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHIINOTIC
+	special 0x163
+
+	setvar 0x8004 SPECIES_HOOTHOOT
+	special 0x163
+
+	setvar 0x8004 SPECIES_NOCTOWL
+	special 0x163
+
+	setvar 0x8004 SPECIES_PICHU
+	special 0x163
+
+	setvar 0x8004 SPECIES_PIKACHU
+	special 0x163
+
+	setvar 0x8004 SPECIES_PIKACHU_CAP_ORIGINAL
+	special 0x163
+
+	setvar 0x8004 SPECIES_RAICHU
+	special 0x163
+
+	setvar 0x8004 SPECIES_BUNEARY
+	special 0x163
+
+	setvar 0x8004 SPECIES_LOPUNNY
+	special 0x163
+
+	setvar 0x8004 SPECIES_LOPUNNY_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHROOMISH
+	special 0x163
+
+	setvar 0x8004 SPECIES_BRELOOM
+	special 0x163
+
+	setvar 0x8004 SPECIES_BONSLY
+	special 0x163
+
+	setvar 0x8004 SPECIES_SUDOWOODO
+	special 0x163
+
+	setvar 0x8004 SPECIES_VENIPEDE
+	special 0x163
+
+	setvar 0x8004 SPECIES_WHIRLIPEDE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SCOLIPEDE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLAKOTH
+	special 0x163
+
+	setvar 0x8004 SPECIES_VIGOROTH
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLAKING
+	special 0x163
+
+	setvar 0x8004 SPECIES_ZUBAT
+	special 0x163
+
+	setvar 0x8004 SPECIES_GOLBAT
+	special 0x163
+
+	setvar 0x8004 SPECIES_CROBAT
+	special 0x163
+
+	setvar 0x8004 SPECIES_DRILBUR
+	special 0x163
+
+	setvar 0x8004 SPECIES_EXCADRILL
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROGGENROLA
+	special 0x163
+
+	setvar 0x8004 SPECIES_BOLDORE
+	special 0x163
+
+	setvar 0x8004 SPECIES_GIGALITH
+	special 0x163
+
+	setvar 0x8004 SPECIES_LILLIPUP
+	special 0x163
+
+	setvar 0x8004 SPECIES_HERDIER
+	special 0x163
+
+	setvar 0x8004 SPECIES_STOUTLAND
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHINCHOU
+	special 0x163
+
+	setvar 0x8004 SPECIES_LANTURN
+	special 0x163
+
+	setvar 0x8004 SPECIES_RATTATA_A
+	special 0x163
+
+	setvar 0x8004 SPECIES_RATICATE_A
+	special 0x163
+
+	setvar 0x8004 SPECIES_FARFETCHD_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_SIRFETCHD
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLETCHLING
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLETCHINDER
+	special 0x163
+
+	setvar 0x8004 SPECIES_TALONFLAME
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLABEBE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLABEBE_BLUE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLABEBE_ORANGE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLABEBE_YELLOW
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLABEBE_WHITE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLOETTE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLOETTE_BLUE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLOETTE_ORANGE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLOETTE_YELLOW
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLOETTE_WHITE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLORGES
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLORGES_BLUE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLORGES_ORANGE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLORGES_YELLOW
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLORGES_WHITE
+	special 0x163
+
+	setvar 0x8004 SPECIES_CUTIEFLY
+	special 0x163
+
+	setvar 0x8004 SPECIES_RIBOMBEE
+	special 0x163
+
+	setvar 0x8004 SPECIES_RALTS
+	special 0x163
+
+	setvar 0x8004 SPECIES_KIRLIA
+	special 0x163
+
+	setvar 0x8004 SPECIES_GARDEVOIR
+	special 0x163
+
+	setvar 0x8004 SPECIES_GARDEVOIR_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_GALLADE
+	special 0x163
+
+	setvar 0x8004 SPECIES_GALLADE_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_FERROSEED
+	special 0x163
+
+	setvar 0x8004 SPECIES_FERROTHORN
+	special 0x163
+
+	setvar 0x8004 SPECIES_COMBEE
+	special 0x163
+
+	setvar 0x8004 SPECIES_VESPIQUEN
+	special 0x163
+
+	setvar 0x8004 SPECIES_SCRAGGY
+	special 0x163
+
+	setvar 0x8004 SPECIES_SCRAFTY
+	special 0x163
+
+	setvar 0x8004 SPECIES_CACNEA
+	special 0x163
+
+	setvar 0x8004 SPECIES_CACTURNE
+	special 0x163
+
+	setvar 0x8004 SPECIES_WINGULL
+	special 0x163
+
+	setvar 0x8004 SPECIES_PELIPPER
+	special 0x163
+
+	setvar 0x8004 SPECIES_HELIOPTILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_HELIOLISK
+	special 0x163
+
+	setvar 0x8004 SPECIES_VULLABY
+	special 0x163
+
+	setvar 0x8004 SPECIES_MANDIBUZZ
+	special 0x163
+
+	setvar 0x8004 SPECIES_CASTFORM
+	special 0x163
+
+	setvar 0x8004 SPECIES_TRAPINCH
+	special 0x163
+
+	setvar 0x8004 SPECIES_VIBRAVA
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLYGON
+	special 0x163
+
+	setvar 0x8004 SPECIES_SANDILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_KROKOROK
+	special 0x163
+
+	setvar 0x8004 SPECIES_KROOKODILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_HIPPOPOTAS
+	special 0x163
+
+	setvar 0x8004 SPECIES_HIPPOPOTAS_F
+	special 0x163
+
+	setvar 0x8004 SPECIES_HIPPOWDON
+	special 0x163
+
+	setvar 0x8004 SPECIES_HIPPOWDON_F
+	special 0x163
+
+	setvar 0x8004 SPECIES_CORPHISH
+	special 0x163
+
+	setvar 0x8004 SPECIES_CRAWDAUNT
+	special 0x163
+
+	setvar 0x8004 SPECIES_MAGIKARP
+	special 0x163
+
+	setvar 0x8004 SPECIES_GYARADOS
+	special 0x163
+
+	setvar 0x8004 SPECIES_GYARADOS_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_INKAY
+	special 0x163
+
+	setvar 0x8004 SPECIES_MALAMAR
+	special 0x163
+
+	setvar 0x8004 SPECIES_NINCADA
+	special 0x163
+
+	setvar 0x8004 SPECIES_NINJASK
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHEDINJA
+	special 0x163
+
+	setvar 0x8004 SPECIES_WYNAUT
+	special 0x163
+
+	setvar 0x8004 SPECIES_WOBBUFFET
+	special 0x163
+
+	setvar 0x8004 SPECIES_CARBINK
+	special 0x163
+
+	setvar 0x8004 SPECIES_KLINK
+	special 0x163
+
+	setvar 0x8004 SPECIES_KLINKLANG
+	special 0x163
+
+	setvar 0x8004 SPECIES_KLANG
+	special 0x163
+
+	setvar 0x8004 SPECIES_KLINKLANG
+	special 0x163
+
+	setvar 0x8004 SPECIES_SABLEYE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SABLEYE_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_MAWILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_MAWILE_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHUCKLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_JANGMO_O
+	special 0x163
+
+	setvar 0x8004 SPECIES_HAKAMO_O
+	special 0x163
+
+	setvar 0x8004 SPECIES_KOMMO_O
+	special 0x163
+
+	setvar 0x8004 SPECIES_CUBCHOO
+	special 0x163
+
+	setvar 0x8004 SPECIES_BEARTIC
+	special 0x163
+
+	setvar 0x8004 SPECIES_SWINUB
+	special 0x163
+
+	setvar 0x8004 SPECIES_PILOSWINE
+	special 0x163
+
+	setvar 0x8004 SPECIES_MAMOSWINE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SNORUNT
+	special 0x163
+
+	setvar 0x8004 SPECIES_GLALIE
+	special 0x163
+
+	setvar 0x8004 SPECIES_GLALIE_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_FROSLASS
+	special 0x163
+
+	setvar 0x8004 SPECIES_NOIBAT
+	special 0x163
+
+	setvar 0x8004 SPECIES_NOIVERN
+	special 0x163
+
+	setvar 0x8004 SPECIES_TYRUNT
+	special 0x163
+
+	setvar 0x8004 SPECIES_TYRANTRUM
+	special 0x163
+
+	setvar 0x8004 SPECIES_SNEASEL
+	special 0x163
+
+	setvar 0x8004 SPECIES_WEAVILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SNOM
+	special 0x163
+
+	setvar 0x8004 SPECIES_FROSMOTH
+	special 0x163
+
+	setvar 0x8004 SPECIES_DARUMAKA_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_DARMANITAN_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_DARMANITAN_G_ZEN
+	special 0x163
+
+	setvar 0x8004 SPECIES_HOUNDOUR
+	special 0x163
+
+	setvar 0x8004 SPECIES_HOUNDOOM
+	special 0x163
+
+	setvar 0x8004 SPECIES_HOUNDOOM_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_LARVESTA
+	special 0x163
+
+	setvar 0x8004 SPECIES_VOLCARONA
+	special 0x163
+
+	setvar 0x8004 SPECIES_MINIOR_SHIELD
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROLYCOLY
+	special 0x163
+
+	setvar 0x8004 SPECIES_CARKOL
+	special 0x163
+
+	setvar 0x8004 SPECIES_COALOSSAL
+	special 0x163
+
+	setvar 0x8004 SPECIES_SKARMORY
+	special 0x163
+
+	setvar 0x8004 SPECIES_SALANDIT
+	special 0x163
+
+	setvar 0x8004 SPECIES_SALAZZLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FRILLISH
+	special 0x163
+
+	setvar 0x8004 SPECIES_FRILLISH_F
+	special 0x163
+
+	setvar 0x8004 SPECIES_JELLICENT
+	special 0x163
+
+	setvar 0x8004 SPECIES_JELLICENT_F
+	special 0x163
+
+	setvar 0x8004 SPECIES_FOONGUS
+	special 0x163
+
+	setvar 0x8004 SPECIES_AMOONGUSS
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHIELDON
+	special 0x163
+
+	setvar 0x8004 SPECIES_BASTIODON
+	special 0x163
+
+	setvar 0x8004 SPECIES_TIMBURR
+	special 0x163
+
+	setvar 0x8004 SPECIES_GURDURR
+	special 0x163
+
+	setvar 0x8004 SPECIES_CONKELDURR
+	special 0x163
+
+	setvar 0x8004 SPECIES_AMAURA
+	special 0x163
+
+	setvar 0x8004 SPECIES_AURORUS
+	special 0x163
+
+	setvar 0x8004 SPECIES_TURTONATOR
+	special 0x163
+
+	setvar 0x8004 SPECIES_MIME_JR_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_MR_MIME_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_MR_RIME
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLUGMA
+	special 0x163
+
+	setvar 0x8004 SPECIES_MAGCARGO
+	special 0x163
+
+	setvar 0x8004 SPECIES_HATENNA
+	special 0x163
+
+	setvar 0x8004 SPECIES_HATTREM
+	special 0x163
+
+	setvar 0x8004 SPECIES_HATTERENE
+	special 0x163
+
+	setvar 0x8004 SPECIES_ORANGURU
+	special 0x163
+
+	setvar 0x8004 SPECIES_PASSIMIAN
+	special 0x163
+
+	setvar 0x8004 SPECIES_TORKOAL
+	special 0x163
+
+	setvar 0x8004 SPECIES_LILEEP
+	special 0x163
+
+	setvar 0x8004 SPECIES_CRADILY
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHELLDER
+	special 0x163
+
+	setvar 0x8004 SPECIES_CLOYSTER
+	special 0x163
+
+	setvar 0x8004 SPECIES_SIZZLIPEDE
+	special 0x163
+
+	setvar 0x8004 SPECIES_CENTISKORCH
+	special 0x163
+
+	setvar 0x8004 SPECIES_COTTONEE
+	special 0x163
+
+	setvar 0x8004 SPECIES_WHIMSICOTT
+	special 0x163
+
+	setvar 0x8004 SPECIES_DITTO
+	special 0x163
+
+	setvar 0x8004 SPECIES_EEVEE
+	special 0x163
+
+	setvar 0x8004 SPECIES_VAPOREON
+	special 0x163
+
+	setvar 0x8004 SPECIES_JOLTEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLAREON
+	special 0x163
+
+	setvar 0x8004 SPECIES_ESPEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_UMBREON
+	special 0x163
+
+	setvar 0x8004 SPECIES_LEAFEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_GLACEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_SYLVEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_MAREEP
+	special 0x163
+
+	setvar 0x8004 SPECIES_FLAAFFY
+	special 0x163
+
+	setvar 0x8004 SPECIES_AMPHAROS
+	special 0x163
+
+	setvar 0x8004 SPECIES_AMPHAROS_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOGEPI
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOGETIC
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOGEKISS
+	special 0x163
+
+	setvar 0x8004 SPECIES_MUDBRAY
+	special 0x163
+
+	setvar 0x8004 SPECIES_MUDSDALE
+	special 0x163
+
+	setvar 0x8004 SPECIES_HAPPINY
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHANSEY
+	special 0x163
+
+	setvar 0x8004 SPECIES_BLISSEY
+	special 0x163
+
+	setvar 0x8004 SPECIES_MIENFOO
+	special 0x163
+
+	setvar 0x8004 SPECIES_MIENSHAO
+	special 0x163
+
+	setvar 0x8004 SPECIES_SKIDDO
+	special 0x163
+
+	setvar 0x8004 SPECIES_GOGOAT
+	special 0x163
+
+	setvar 0x8004 SPECIES_RIOLU
+	special 0x163
+
+	setvar 0x8004 SPECIES_LUCARIO
+	special 0x163
+
+	setvar 0x8004 SPECIES_LUCARIO_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_DRATINI
+	special 0x163
+
+	setvar 0x8004 SPECIES_DRAGONAIR
+	special 0x163
+
+	setvar 0x8004 SPECIES_DRAGONITE
+	special 0x163
+
+	setvar 0x8004 SPECIES_PACHIRISU
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROTOM
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROTOM_HEAT
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROTOM_WASH
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROTOM_FROST
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROTOM_FAN
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROTOM_MOW
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOXEL
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOXTRICITY
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOXTRICITY_LOW_KEY
+	special 0x163
+
+	setvar 0x8004 SPECIES_HORSEA
+	special 0x163
+
+	setvar 0x8004 SPECIES_SEADRA
+	special 0x163
+
+	setvar 0x8004 SPECIES_KINGDRA
+	special 0x163
+
+	setvar 0x8004 SPECIES_CROAGUNK
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOXICROAK
+	special 0x163
+
+	setvar 0x8004 SPECIES_GOOMY
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLIGGOO
+	special 0x163
+
+	setvar 0x8004 SPECIES_GOODRA
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHELLOS
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHELLOS_EAST
+	special 0x163
+
+	setvar 0x8004 SPECIES_GASTRODON
+	special 0x163
+
+	setvar 0x8004 SPECIES_GASTRODON_EAST
+	special 0x163
+
+	setvar 0x8004 SPECIES_MIMIKYU
+	special 0x163
+
+	setvar 0x8004 SPECIES_MIMIKYU_BUSTED
+	special 0x163
+
+	setvar 0x8004 SPECIES_DUSKULL
+	special 0x163
+
+	setvar 0x8004 SPECIES_DUSCLOPS
+	special 0x163
+
+	setvar 0x8004 SPECIES_DUSKNOIR
+	special 0x163
+
+	setvar 0x8004 SPECIES_EMOLGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_CARVANHA
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHARPEDO
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHARPEDO_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_HERACROSS
+	special 0x163
+
+	setvar 0x8004 SPECIES_HERACROSS_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_YAMASK
+	special 0x163
+
+	setvar 0x8004 SPECIES_YAMASK_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_COFAGRIGUS
+	special 0x163
+
+	setvar 0x8004 SPECIES_RUNERIGUS
+	special 0x163
+
+	setvar 0x8004 SPECIES_DHELMISE
+	special 0x163
+
+	setvar 0x8004 SPECIES_PINCURCHIN
+	special 0x163
+
+	setvar 0x8004 SPECIES_MORPEKO
+	special 0x163
+
+	setvar 0x8004 SPECIES_MORPEKO_HANGRY
+	special 0x163
+
+	setvar 0x8004 SPECIES_STUNFISK_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_MISDREAVUS
+	special 0x163
+
+	setvar 0x8004 SPECIES_MISMAGIUS
+	special 0x163
+
+	setvar 0x8004 SPECIES_GRIMER_A
+	special 0x163
+
+	setvar 0x8004 SPECIES_MUK_A
+	special 0x163
+
+	setvar 0x8004 SPECIES_GIBLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_GABITE
+	special 0x163
+
+	setvar 0x8004 SPECIES_GARCHOMP
+	special 0x163
+
+	setvar 0x8004 SPECIES_GARCHOMP_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_BINACLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_BARBARACLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_MAREANIE
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOXAPEX
+	special 0x163
+
+	setvar 0x8004 SPECIES_KOFFING
+	special 0x163
+
+	setvar 0x8004 SPECIES_KOFFING_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_WEEZING
+	special 0x163
+
+	setvar 0x8004 SPECIES_WEEZING_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_ZORUA
+	special 0x163
+
+	setvar 0x8004 SPECIES_ZOROARK
+	special 0x163
+
+	setvar 0x8004 SPECIES_LAPRAS
+	special 0x163
+
+	setvar 0x8004 SPECIES_CRABRAWLER
+	special 0x163
+
+	setvar 0x8004 SPECIES_CRABOMINABLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_PHANTUMP
+	special 0x163
+
+	setvar 0x8004 SPECIES_TREVENANT
+	special 0x163
+
+	setvar 0x8004 SPECIES_SANDYGAST
+	special 0x163
+
+	setvar 0x8004 SPECIES_PALOSSAND
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLOWPOKE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLOWBRO
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLOWBRO_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_SLOWKING
+	special 0x163
+
+	setvar 0x8004 SPECIES_CORSOLA_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_CURSOLA
+	special 0x163
+
+	setvar 0x8004 SPECIES_FALINKS
+	special 0x163
+
+	setvar 0x8004 SPECIES_PAWNIARD
+	special 0x163
+
+	setvar 0x8004 SPECIES_BISHARP
+	special 0x163
+
+	setvar 0x8004 SPECIES_ELGYEM
+	special 0x163
+
+	setvar 0x8004 SPECIES_BEHEEYEM
+	special 0x163
+
+	setvar 0x8004 SPECIES_MANKEY
+	special 0x163
+
+	setvar 0x8004 SPECIES_PRIMEAPE
+	special 0x163
+
+	setvar 0x8004 SPECIES_BERGMITE
+	special 0x163
+
+	setvar 0x8004 SPECIES_AVALUGG
+	special 0x163
+
+	setvar 0x8004 SPECIES_STONJOURNER
+	special 0x163
+
+	setvar 0x8004 SPECIES_DELIBIRD
+	special 0x163
+
+	setvar 0x8004 SPECIES_COMFEY
+	special 0x163
+
+	setvar 0x8004 SPECIES_CUFANT
+	special 0x163
+
+	setvar 0x8004 SPECIES_COPPERAJAH
+	special 0x163
+
+	setvar 0x8004 SPECIES_JOLTIK
+	special 0x163
+
+	setvar 0x8004 SPECIES_GALVANTULA
+	special 0x163
+
+	setvar 0x8004 SPECIES_CARNIVINE
+	special 0x163
+
+	setvar 0x8004 SPECIES_LITLEO
+	special 0x163
+
+	setvar 0x8004 SPECIES_PYROAR
+	special 0x163
+
+	setvar 0x8004 SPECIES_PYROAR_FEMALE
+	special 0x163
+
+	setvar 0x8004 SPECIES_KANGASKHAN
+	special 0x163
+
+	setvar 0x8004 SPECIES_KANGASKHAN_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_DURALUDON
+	special 0x163
+
+	setvar 0x8004 SPECIES_ARTICUNO_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_ZAPDOS_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_MOLTRES_G
+	special 0x163
+
+	setvar 0x8004 SPECIES_JIRACHI
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHAYMIN
+	special 0x163
+
+	setvar 0x8004 SPECIES_SHAYMIN_SKY
+	special 0x163
+
+	setvar 0x8004 SPECIES_KYOGRE
+	special 0x163
+
+	setvar 0x8004 SPECIES_KYOGRE_PRIMAL
+	special 0x163
+
+	setvar 0x8004 SPECIES_GROUDON
+	special 0x163
+
+	setvar 0x8004 SPECIES_GROUDON_PRIMAL
+	special 0x163
+
+	setvar 0x8004 SPECIES_VOLCANION
+	special 0x163
+
+	setvar 0x8004 SPECIES_ZARUDE
+	special 0x163
+
+	setvar 0x8004 SPECIES_ZARUDE_DADA
+	special 0x163
+
+	setvar 0x8004 SPECIES_GLASTRIER
+	special 0x163
+
+	setvar 0x8004 SPECIES_MELTAN
+	special 0x163
+
+	setvar 0x8004 SPECIES_MELMETAL
+	special 0x163
+
+	setvar 0x8004 SPECIES_VICTINI
+	special 0x163
+
+	setvar 0x8004 SPECIES_BULBASAUR
+	special 0x163
+
+	setvar 0x8004 SPECIES_IVYSAUR
+	special 0x163
+
+	setvar 0x8004 SPECIES_VENUSAUR
+	special 0x163
+
+	setvar 0x8004 SPECIES_VENUSAUR_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHARMANDER
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHARMELEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHARIZARD
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHARIZARD_MEGA_X
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHARIZARD_MEGA_Y
+	special 0x163
+
+	setvar 0x8004 SPECIES_SQUIRTLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_WARTORTLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_BLASTOISE
+	special 0x163
+
+	setvar 0x8004 SPECIES_BLASTOISE_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHIKORITA
+	special 0x163
+
+	setvar 0x8004 SPECIES_BAYLEEF
+	special 0x163
+
+	setvar 0x8004 SPECIES_MEGANIUM
+	special 0x163
+
+	setvar 0x8004 SPECIES_CYNDAQUIL
+	special 0x163
+
+	setvar 0x8004 SPECIES_QUILAVA
+	special 0x163
+
+	setvar 0x8004 SPECIES_TYPHLOSION
+	special 0x163
+
+	setvar 0x8004 SPECIES_TOTODILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_CROCONAW
+	special 0x163
+
+	setvar 0x8004 SPECIES_FERALIGATR
+	special 0x163
+
+	setvar 0x8004 SPECIES_TREECKO
+	special 0x163
+
+	setvar 0x8004 SPECIES_GROVYLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SCEPTILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SCEPTILE_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_TORCHIC
+	special 0x163
+
+	setvar 0x8004 SPECIES_COMBUSKEN
+	special 0x163
+
+	setvar 0x8004 SPECIES_BLAZIKEN
+	special 0x163
+
+	setvar 0x8004 SPECIES_BLAZIKEN_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_MUDKIP
+	special 0x163
+
+	setvar 0x8004 SPECIES_MARSHTOMP
+	special 0x163
+
+	setvar 0x8004 SPECIES_SWAMPERT
+	special 0x163
+
+	setvar 0x8004 SPECIES_SWAMPERT_MEGA
+	special 0x163
+
+	setvar 0x8004 SPECIES_TURTWIG
+	special 0x163
+
+	setvar 0x8004 SPECIES_GROTLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_TORTERRA
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHIMCHAR
+	special 0x163
+
+	setvar 0x8004 SPECIES_MONFERNO
+	special 0x163
+
+	setvar 0x8004 SPECIES_INFERNAPE
+	special 0x163
+
+	setvar 0x8004 SPECIES_PIPLUP
+	special 0x163
+
+	setvar 0x8004 SPECIES_PRINPLUP
+	special 0x163
+
+	setvar 0x8004 SPECIES_EMPOLEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_SNIVY
+	special 0x163
+
+	setvar 0x8004 SPECIES_SERVINE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SERPERIOR
+	special 0x163
+
+	setvar 0x8004 SPECIES_TEPIG
+	special 0x163
+
+	setvar 0x8004 SPECIES_PIGNITE
+	special 0x163
+
+	setvar 0x8004 SPECIES_EMBOAR
+	special 0x163
+
+	setvar 0x8004 SPECIES_OSHAWOTT
+	special 0x163
+
+	setvar 0x8004 SPECIES_DEWOTT
+	special 0x163
+
+	setvar 0x8004 SPECIES_SAMUROTT
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHESPIN
+	special 0x163
+
+	setvar 0x8004 SPECIES_QUILLADIN
+	special 0x163
+
+	setvar 0x8004 SPECIES_CHESNAUGHT
+	special 0x163
+
+	setvar 0x8004 SPECIES_FENNEKIN
+	special 0x163
+
+	setvar 0x8004 SPECIES_BRAIXEN
+	special 0x163
+
+	setvar 0x8004 SPECIES_DELPHOX
+	special 0x163
+
+	setvar 0x8004 SPECIES_FROAKIE
+	special 0x163
+
+	setvar 0x8004 SPECIES_FROGADIER
+	special 0x163
+
+	setvar 0x8004 SPECIES_GRENINJA
+	special 0x163
+
+	setvar 0x8004 SPECIES_ROWLET
+	special 0x163
+
+	setvar 0x8004 SPECIES_DARTRIX
+	special 0x163
+
+	setvar 0x8004 SPECIES_DECIDUEYE
+	special 0x163
+
+	setvar 0x8004 SPECIES_LITTEN
+	special 0x163
+
+	setvar 0x8004 SPECIES_TORRACAT
+	special 0x163
+
+	setvar 0x8004 SPECIES_INCINEROAR
+	special 0x163
+
+	setvar 0x8004 SPECIES_POPPLIO
+	special 0x163
+
+	setvar 0x8004 SPECIES_BRIONNE
+	special 0x163
+
+	setvar 0x8004 SPECIES_PRIMARINA
+	special 0x163
+
+	setvar 0x8004 SPECIES_GROOKEY
+	special 0x163
+
+	setvar 0x8004 SPECIES_THWACKEY
+	special 0x163
+
+	setvar 0x8004 SPECIES_RILLABOOM
+	special 0x163
+
+	setvar 0x8004 SPECIES_SCORBUNNY
+	special 0x163
+
+	setvar 0x8004 SPECIES_RABOOT
+	special 0x163
+
+	setvar 0x8004 SPECIES_CINDERACE
+	special 0x163
+
+	setvar 0x8004 SPECIES_SOBBLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_DRIZZILE
+	special 0x163
+
+	setvar 0x8004 SPECIES_INTELEON
+	special 0x163
+
+	setvar 0x8004 SPECIES_COSMOG
+	special 0x163
+
+	setvar 0x8004 SPECIES_COSMOEM
+	special 0x163
+
+	setvar 0x8004 SPECIES_SOLGALEO
+	special 0x163
+
+	setvar 0x8004 SPECIES_LUNALA
+	special 0x163
+
+	setvar 0x8004 SPECIES_NIHILEGO
+	special 0x163
+
+	setvar 0x8004 SPECIES_BUZZWOLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_PHEROMOSA
+	special 0x163
+
+	setvar 0x8004 SPECIES_XURKITREE
+	special 0x163
+
+	setvar 0x8004 SPECIES_CELESTEELA
+	special 0x163
+
+	setvar 0x8004 SPECIES_KARTANA
+	special 0x163
+
+	setvar 0x8004 SPECIES_GUZZLORD
+	special 0x163
+
+	setvar 0x8004 SPECIES_NECROZMA
+	special 0x163
+
+	setvar 0x8004 SPECIES_NECROZMA_DUSK_MANE
+	special 0x163
+
+	setvar 0x8004 SPECIES_NECROZMA_DAWN_WINGS
+	special 0x163
+
+	setvar 0x8004 SPECIES_NECROZMA_ULTRA
+	special 0x163
+
+	setvar 0x8004 SPECIES_POIPOLE
+	special 0x163
+
+	setvar 0x8004 SPECIES_NAGANADEL
+	special 0x163
+
+	setvar 0x8004 SPECIES_STAKATAKA
+	special 0x163
+
+	setvar 0x8004 SPECIES_BLACEPHALON
+	special 0x163
+
+	@ Give the player certain key items, like mega/primal reversion/ultra burst items
+	setflag 0x828 @ Enable Pokemon Menu
+	setflag 0x829 @ Enable Pokedex Menu
+	giveitem ITEM_POKE_BALL 0x32 MSG_FIND @Give 50 pokeballs
+	giveitem ITEM_RARE_CANDY 0x1E MSG_FIND @Give 30 rare candies
+	additem ITEM_TOWN_MAP 0x1 @ Give town map
+	@ giveitem2 0x169 0x1 0x13E @ Give town map with fanfare (base game uses both)

--- a/assembly/debug/starter_choice.s
+++ b/assembly/debug/starter_choice.s
@@ -1,0 +1,16 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+
+.global EventScript_StarterChoice_Main
+EventScript_StarterChoice_Main:
+	buffernumber 0x0 0x4011
+	msgbox gText_StarterChoice_Npctextg MSG_FACE
+	buffernumber 0x0 0x4012
+	msgbox gText_StarterChoice_Npctextf MSG_FACE
+	buffernumber 0x0 0x4013
+	msgbox gText_StarterChoice_Npctextw MSG_FACE
+	end
+

--- a/assembly/overworld_scripts/game_modifiers.s
+++ b/assembly/overworld_scripts/game_modifiers.s
@@ -1,0 +1,194 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+
+@ TODO: Trigger this only on game clear. See how system_scripts.s uses callasm DebugMenu_ProcessSetFlag
+.global EventScript_Modifiers_Main
+EventScript_Modifiers_Main:
+	lock
+	sound 0x2 @Log on SE
+	msgbox gText_Modifiers_Msginteract MSG_KEEPOPEN
+	multichoiceoption gText_Modifiers_OptionInverse 0
+	multichoiceoption gText_Modifiers_OptionCatchTrainer 1
+	multichoiceoption gText_Modifiers_OptionScaleWild 2
+	multichoiceoption gText_Modifiers_OptionScaleTrainer 3
+	multichoiceoption gText_Modifiers_OptionHiddenAbilities 4
+	multichoiceoption gText_Modifiers_OptionShinies 5
+	multichoiceoption gText_Modifiers_OptionRandomizer 6
+	multichoice 0x60 0x0 SEVEN_MULTICHOICE_OPTIONS 0x0
+	copyvar 0x40FE LASTRESULT
+	switch LASTRESULT
+	case 0, EventScript_Modifiers_Inversebattle
+	case 1, EventScript_Modifiers_Catchtrainer
+	case 2, EventScript_Modifiers_Scalewild
+	case 3, EventScript_Modifiers_Scaletrainer
+	case 4, EventScript_Modifiers_Hiddenability
+	case 5, EventScript_Modifiers_Shiny
+	case 6, EventScript_Modifiers_Randomizer
+	call EventScript_Modifiers_End
+	end
+
+.global EventScript_Modifiers_Inversebattle
+EventScript_Modifiers_Inversebattle:
+	msgbox gText_Modifiers_Msginverse MSG_KEEPOPEN
+	checkflag 0x900
+	if 0x0 _call EventScript_Modifiers_Flagisoff
+	if 0x1 _call EventScript_Modifiers_Flagison
+	end
+
+.global EventScript_Modifiers_Catchtrainer
+EventScript_Modifiers_Catchtrainer:
+	msgbox gText_Modifiers_Msgcatchtrainer MSG_KEEPOPEN
+	checkflag 0x905
+	if 0x0 _call EventScript_Modifiers_Flagisoff
+	if 0x1 _call EventScript_Modifiers_Flagison
+	end
+
+.global EventScript_Modifiers_Scalewild
+EventScript_Modifiers_Scalewild:
+	msgbox gText_Modifiers_Msgscalewild MSG_KEEPOPEN
+	checkflag 0x90D
+	if 0x0 _call EventScript_Modifiers_Flagisoff
+	if 0x1 _call EventScript_Modifiers_Flagison
+	end
+
+.global EventScript_Modifiers_Scaletrainer
+EventScript_Modifiers_Scaletrainer:
+	msgbox gText_Modifiers_Msgscaletrainer MSG_KEEPOPEN
+	checkflag 0x90E
+	if 0x0 _call EventScript_Modifiers_Flagisoff
+	if 0x1 _call EventScript_Modifiers_Flagison
+	end
+
+.global EventScript_Modifiers_Hiddenability
+EventScript_Modifiers_Hiddenability:
+	msgbox gText_Modifiers_Msghiddenability MSG_KEEPOPEN
+	checkflag 0x90F
+	if 0x0 _call EventScript_Modifiers_Flagisoff
+	if 0x1 _call EventScript_Modifiers_Flagison
+	end
+
+.global EventScript_Modifiers_Shiny
+EventScript_Modifiers_Shiny:
+	msgbox gText_Modifiers_Msgshiny MSG_KEEPOPEN
+	checkflag 0x913
+	if 0x0 _call EventScript_Modifiers_Flagisoff
+	if 0x1 _call EventScript_Modifiers_Flagison
+	end
+
+.global EventScript_Modifiers_Randomizer
+EventScript_Modifiers_Randomizer:
+	msgbox gText_Modifiers_Msgrandomizer MSG_KEEPOPEN
+	checkflag 0x940
+	if 0x0 _call EventScript_Modifiers_Flagisoff
+	if 0x1 _call EventScript_Modifiers_Flagison
+	end
+
+.global EventScript_Modifiers_Flagisoff
+EventScript_Modifiers_Flagisoff:
+	msgbox gText_Modifiers_Msgflagisoff MSG_YESNO
+	compare LASTRESULT 0x1
+	if 0x0 _call EventScript_Modifiers_Main
+	call EventScript_Modifiers_Flagnowon
+
+.global EventScript_Modifiers_Flagison
+EventScript_Modifiers_Flagison:
+	msgbox gText_Modifiers_Msgflagison MSG_YESNO
+	compare LASTRESULT 0x1
+	if 0x0 _call EventScript_Modifiers_Main
+	call EventScript_Modifiers_Flagnowoff
+
+.global EventScript_Modifiers_Flagnowoff
+EventScript_Modifiers_Flagnowoff:
+	sound 0x30 @Save
+	msgbox gText_Modifiers_Msgflagnowoff MSG_KEEPOPEN
+	switch 0x40FE
+	case 0, EventScript_Modifiers_Clearinverse
+	case 1, EventScript_Modifiers_Clearcatchtrainer
+	case 2, EventScript_Modifiers_Clearscalewild
+	case 3, EventScript_Modifiers_Clearscaletrainer
+	case 4, EventScript_Modifiers_Clearhiddenability
+	case 5, EventScript_Modifiers_Clearshiny
+	case 6, EventScript_Modifiers_Clearrandomizer
+	call EventScript_Modifiers_Main
+
+.global EventScript_Modifiers_Flagnowon
+EventScript_Modifiers_Flagnowon:
+	sound 0x30 @Save
+	msgbox gText_Modifiers_Msgflagnowon MSG_KEEPOPEN
+	switch 0x40FE
+	case 0, EventScript_Modifiers_Setinverse
+	case 1, EventScript_Modifiers_Setcatchtrainer
+	case 2, EventScript_Modifiers_Setscalewild
+	case 3, EventScript_Modifiers_Setscaletrainer
+	case 4, EventScript_Modifiers_Sethiddenability
+	case 5, EventScript_Modifiers_Setshiny
+	case 6, EventScript_Modifiers_Setrandomizer
+	call EventScript_Modifiers_Main
+
+.global EventScript_Modifiers_Clearinverse
+EventScript_Modifiers_Clearinverse:
+	clearflag 0x900 @ Turn off inverse
+
+.global EventScript_Modifiers_Clearcatchtrainer
+EventScript_Modifiers_Clearcatchtrainer:
+	clearflag 0x905 @ Turn off catch trainer
+
+.global EventScript_Modifiers_Clearscalewild
+EventScript_Modifiers_Clearscalewild:
+	clearflag 0x90D @ Turn off scale wild
+
+.global EventScript_Modifiers_Clearscaletrainer
+EventScript_Modifiers_Clearscaletrainer:
+	clearflag 0x90E @ Turn off scale trainer
+
+.global EventScript_Modifiers_Clearhiddenability
+EventScript_Modifiers_Clearhiddenability:
+	clearflag 0x90F @ Turn off hidden ability
+
+.global EventScript_Modifiers_Clearshiny
+EventScript_Modifiers_Clearshiny:
+	clearflag 0x913 @ Turn off shiny
+
+.global EventScript_Modifiers_Clearrandomizer
+EventScript_Modifiers_Clearrandomizer:
+	clearflag 0x940 @ Turn off randomizer
+
+.global EventScript_Modifiers_Setinverse
+EventScript_Modifiers_Setinverse:
+	setflag 0x900 @ Turn on inverse
+
+.global EventScript_Modifiers_Setcatchtrainer
+EventScript_Modifiers_Setcatchtrainer:
+	setflag 0x905 @ Turn on catch trainer
+
+.global EventScript_Modifiers_Setscalewild
+EventScript_Modifiers_Setscalewild:
+	setflag 0x90D @ Turn on scale wild
+
+.global EventScript_Modifiers_Setscaletrainer
+EventScript_Modifiers_Setscaletrainer:
+	setflag 0x90E @ Turn on scale trainer
+
+.global EventScript_Modifiers_Sethiddenability
+EventScript_Modifiers_Sethiddenability:
+	setflag 0x90F @ Turn on hidden ability
+
+.global EventScript_Modifiers_Setshiny
+EventScript_Modifiers_Setshiny:
+	setflag 0x913 @ Turn on shiny
+
+.global EventScript_Modifiers_Setrandomizer
+EventScript_Modifiers_Setrandomizer:
+	setflag 0x940 @ Turn on randomizer
+	clearflag 0x930 @ Hack: turn off the battle facility (which disables randomizer)
+
+.global EventScript_Modifiers_End
+EventScript_Modifiers_End:
+	setvar 0x40FE 0x0
+	sound 0x4 @Log off SE
+	msgbox gText_Modifiers_Msgend MSG_KEEPOPEN
+	release
+	end

--- a/assembly/overworld_scripts/gen_choice.s
+++ b/assembly/overworld_scripts/gen_choice.s
@@ -1,0 +1,129 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+
+.global gMapScripts_GenChoice
+gMapScripts_GenChoice:
+	mapscript MAP_SCRIPT_ON_FRAME_TABLE LevelScripts_GenChoice
+	.byte MAP_SCRIPT_TERMIN
+
+LevelScripts_GenChoice:
+	levelscript 0x4056 0 LevelScript_GenChoice_Main
+	.hword LEVEL_SCRIPT_TERMIN
+
+LevelScript_GenChoice_Main:
+	lock
+	spriteface PLAYER look_down
+	setvar 0x4056 0x1
+	msgbox gText_GenChoice_Msgwelcome MSG_YESNO
+	compare LASTRESULT 0x1
+	if 0x1 _call EventScript_GenChoice_Favoritegen
+	call EventScript_GenChoice_Shuffle
+	end
+
+EventScript_GenChoice_Favoritegen:
+	msgbox gText_GenChoice_Msgfavoritegen MSG_KEEPOPEN
+	multichoice 0x60 0x0 0x1 0x1
+	copyvar 0x4011 LASTRESULT
+	compare 0x4011 0x0
+	if 0x1 _call EventScript_GenChoice_Kantoconfirm
+	compare 0x4011 0x1
+	if 0x1 _call EventScript_GenChoice_Johtoconfirm
+	compare 0x4011 0x2
+	if 0x1 _call EventScript_GenChoice_Hoennconfirm
+	compare 0x4011 0x3
+	if 0x1 _call EventScript_GenChoice_Sinnohconfirm
+	compare 0x4011 0x4
+	if 0x1 _call EventScript_GenChoice_Unovaconfirm
+	compare 0x4011 0x5
+	if 0x1 _call EventScript_GenChoice_Kalosconfirm
+	compare 0x4011 0x6
+	if 0x1 _call EventScript_GenChoice_Alolaconfirm
+	compare 0x4011 0x7
+	if 0x1 _call EventScript_GenChoice_Galarconfirm
+	end
+
+EventScript_GenChoice_Shuffle:
+	msgbox gText_GenChoice_Msgshuffleconfirm MSG_YESNO
+	compare LASTRESULT 0x1
+	if 0x0 _call LevelScript_GenChoice_Main
+	random 0x8
+	copyvar 0x4011 LASTRESULT
+	random 0x8
+	copyvar 0x4012 LASTRESULT
+	random 0x8
+	copyvar 0x4013 LASTRESULT
+	call EventScript_GenChoice_End
+	end
+
+EventScript_GenChoice_Kantoconfirm:
+	msgbox gText_GenChoice_Msgkantoconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x0
+	setvar 0x4013 0x0
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Johtoconfirm:
+	msgbox gText_GenChoice_Msgjohtoconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x1
+	setvar 0x4013 0x1
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Hoennconfirm:
+	msgbox gText_GenChoice_Msghoennconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x2
+	setvar 0x4013 0x2
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Sinnohconfirm:
+	msgbox gText_GenChoice_Msgsinnohconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x3
+	setvar 0x4013 0x3
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Unovaconfirm:
+	msgbox gText_GenChoice_Msgunovaconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x4
+	setvar 0x4013 0x4
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Kalosconfirm:
+	msgbox gText_GenChoice_Msgkalosconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x5
+	setvar 0x4013 0x5
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Alolaconfirm:
+	msgbox gText_GenChoice_Msgalolaconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x6
+	setvar 0x4013 0x6
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Galarconfirm:
+	msgbox gText_GenChoice_Msggalarconfirm MSG_YESNO
+	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x4012 0x7
+	setvar 0x4013 0x7
+	call EventScript_GenChoice_End
+
+EventScript_GenChoice_Genchoiceconfirm:
+	compare LASTRESULT 0x1
+	if 0x0 _call EventScript_GenChoice_Reset
+	return
+
+EventScript_GenChoice_Reset:
+	setvar 0x4011 0x0
+	call LevelScript_GenChoice_Main
+
+EventScript_GenChoice_End:
+	msgbox gText_GenChoice_Msgcomplete MSG_KEEPOPEN
+	release
+	end

--- a/automation/BuildTest.py
+++ b/automation/BuildTest.py
@@ -40,17 +40,19 @@ print("Copying edited GBA ROM to DPE directory...")
 shutil.copy(EDITED_GBA_PATH, DPE_PATH + "/BPRE0.gba")
 
 print("Applying DPE...")
-result = call(["python", DPE_PATH + "/scripts/make.py"])
+os.chdir(DPE_PATH) # Make script must be run in home directory!
+result = call(["python", "./scripts/make.py"])
 if (result != 0):
     print(ERROR_COLOR + "Error applying DPE. See output for details. Exiting with status code: 3")
     exit(3)
 
 print("Copying built GBA ROM to CFRU directory...")
-shutil.copy(DPE_PATH + "/test.gba", CFRU_PATH + "./BPRE0.gba")
+shutil.copy(DPE_PATH + "/test.gba", CFRU_PATH + "/BPRE0.gba")
 
 print("Appyling CFRU...")
+os.chdir(CFRU_PATH) # Make script must be run in home directory!
 # TODO: Add clean.py script as an optional command?
-result = call(["python", CFRU_PATH + "/scripts/make.py"])
+result = call(["python", "./scripts/make.py"])
 if (result != 0):
     print(ERROR_COLOR + "Error applying CFRU. See output for details. Exiting with status code: 4")
     exit(4)

--- a/eventscripts
+++ b/eventscripts
@@ -1,3 +1,20 @@
 ##
 # (Event Type: npc, sign, tile, map) (Map Bank) (Map Number) ("no:" in Advance Map, not "Person Event no:") (Event name)
+# Note: "no." param not used by map type.
+
+# Debug Scripts - Only uncomment when debugging
+# Populate the Pokedex, give pokemon and default items
+# npc 3 0 2 EventScript_DebugMode_Main
+
+# Simple snippet for detecting player's starter choice. Demos how to read flags
+# npc 3 0 3 EventScript_StarterChoice_Main
+
+# Allows player to turn on game modifier settings. Should ideally be locked behind NG+
+# npc 3 0 3 EventScript_Modifiers_Main
+
+# Startup
+# Prompts the player to enter their generation choice
+map 4 1 gMapScripts_GenChoice
+
+# Rhodanzi City
 npc 6 0 0 EventScript_RhodanziTrainerSchool_Receptionist

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -612,12 +612,11 @@ enum EvolutionMethods
 	EVO_OTHER_PARTY_MON,	//another poke in the party, arg is a specific species
 	EVO_LEVEL_SPECIFIC_TIME_RANGE, // above given level with a range (unknown is [start][end]. eg lycanroc -> 1700-1800 hrs -> 0x1112)
 	EVO_FLAG_SET, //If a certain flag is set. Can be used for touching the Mossy/Icy Rock for Leafeon/Glaceon evolutions
-/*	//Evolution Defines Added in DPE
+/*	//Evolution Defines Added in DPE */
 	EVO_CRITICAL_HIT, // successfully land 3 critical hits in one battle
 	EVO_NATURE_HIGH, // evolution based on high key nature at a certain level
 	EVO_NATURE_LOW, // evolution based on low key nature at a certain level
 	EVO_DAMAGE_LOCATION // recieve 49+ damage in battle without fainting, walk to specific tile
-*/
 };
 #define EVO_GIGANTAMAX 0xFD
 #define EVO_MEGA 0xFE

--- a/strings/scripts/game_modifiers.string
+++ b/strings/scripts/game_modifiers.string
@@ -1,0 +1,63 @@
+#org @gText_Modifiers_OptionInverse
+Inverse Battles
+
+#org @gText_Modifiers_OptionCatchTrainer
+Catch Trainer Pokemon
+
+#org @gText_Modifiers_OptionScaleWild
+Scale Wild Pokemon Levels
+
+#org @gText_Modifiers_OptionScaleTrainer
+Scale Trainer Pokemon Levels
+
+#org @gText_Modifiers_OptionHiddenAbilities
+Hidden Abilities
+
+#org @gText_Modifiers_OptionShinies
+Shiny Pokemon
+
+#org @gText_Modifiers_OptionRandomizer
+Randomize Pokemon
+
+#org @gText_Modifiers_Msginteract
+This terminal allows you to set\ngame modifiers.\l[RED]WARNING: It is recommended to only\lset these after completing the game\las it was intended.\l[BLACK]Please make a selection.
+
+#org @gText_Modifiers_Msginverse
+Type effectiveness will be\nreversed in battle.
+
+#org @gText_Modifiers_Foo
+Allows you to capture Pok\emon\nin trainer battles.
+
+#org @gText_Modifiers_Msgcatchtrainer
+Allows you to capture Pok\emon\nin trainer battles.
+
+#org @gText_Modifiers_Msgscalewild
+All wild Pok\emon's levels will be\nscaled to the lowest level in your\lparty.
+
+#org @gText_Modifiers_Msgscaletrainer
+All trainers' Pok\emon's levels\nwill be scaled to the highest\llevel in your party.
+
+#org @gText_Modifiers_Msghiddenability
+All wild pokemon will have their\nhidden abilities.
+
+#org @gText_Modifiers_Msgshiny
+All wild Pok\emon will be shiny.
+
+#org @gText_Modifiers_Msgrandomizer
+All wild and trainer Pok\emon are\nrandomized.
+
+#org @gText_Modifiers_Msgflagisoff
+The modifier is currently off.\nWould you like to turn it on?
+
+#org @gText_Modifiers_Msgflagison
+The modifier is currently on.\nWould you like to turn it off?
+
+#org @gText_Modifiers_Msgflagnowoff
+The modifier has been disabled.
+
+#org @gText_Modifiers_Msgflagnowon
+The modifier has been enabled.
+
+#org @gText_Modifiers_Msgend
+Logging off...
+

--- a/strings/scripts/gen_choice.string
+++ b/strings/scripts/gen_choice.string
@@ -1,0 +1,36 @@
+#org @gText_GenChoice_Msgwelcome
+Welcome to Pok\emon Shooting Stars!\pWe have a couple questions to help\ncustomize your experience.\pFirst of all, do you have a\nfavorite Pok\emon generation?
+
+#org @gText_GenChoice_Msgfavoritegen
+Please select your favorite\ngeneration.
+
+#org @gText_GenChoice_Msgshuffleconfirm
+The game will be set in shuffle\nmode. This will choose random\lstarters from across all 8\lgenerations.\pDo you want to start in shuffle\nmode?
+
+#org @gText_GenChoice_Msgkantoconfirm
+Your favorite generation is 1\n(Kanto)?
+
+#org @gText_GenChoice_Msgjohtoconfirm
+Your favorite generation is 2\n(Johto)?
+
+#org @gText_GenChoice_Msghoennconfirm
+Your favorite generation is 3\n(Hoenn)?
+
+#org @gText_GenChoice_Msgsinnohconfirm
+Your favorite generation is 4\n(Sinnoh)?
+
+#org @gText_GenChoice_Msgunovaconfirm
+Your favorite generation is 5\n(Unova)?
+
+#org @gText_GenChoice_Msgkalosconfirm
+Your favorite generation is 6\n(Kalos)?
+
+#org @gText_GenChoice_Msgalolaconfirm
+Your favorite generation is 7\n(Alola)?
+
+#org @gText_GenChoice_Msggalarconfirm
+Your favorite generation is 8\n(Galar)?
+
+#org @gText_GenChoice_Msgcomplete
+Selection confirmed. We hope you\nenjoy Pok\emon Shooting Stars!
+

--- a/strings/scripts/starter_choice.string
+++ b/strings/scripts/starter_choice.string
@@ -1,0 +1,8 @@
+#org @gText_StarterChoice_Npctextg
+Grass starter gen is [BUFFER1]!
+
+#org @gText_StarterChoice_Npctextf
+Fire starter gen is [BUFFER1]!
+
+#org @gText_StarterChoice_Npctextw
+Water starter gen is [BUFFER1]!


### PR DESCRIPTION
Convert and integrate scripts that were previously assigned to specific memory addresses.  They are now injected through CFRU.

Closes #6 