### PR TITLE
Badge based pokemarts

### DIFF
--- a/assembly/overworld_scripts/anthra_town/anthra_town.s
+++ b/assembly/overworld_scripts/anthra_town/anthra_town.s
@@ -19,7 +19,7 @@ EventScript_AnthraTown_MomMain:
 	lock
 	faceplayer
 	checkflag 0x258
-	if TRUE _goto EventScript_AnthraTown_MomRestPrompt
+	if SET _goto EventScript_AnthraTown_MomRestPrompt
 	msgbox gText_AnthraTown_MomLeaveHome MSG_KEEPOPEN
 	closeonkeypress
 	applymovement 0x1 m_LookLeft

--- a/assembly/overworld_scripts/game_modifiers.s
+++ b/assembly/overworld_scripts/game_modifiers.s
@@ -34,56 +34,56 @@ EventScript_Modifiers_Main:
 EventScript_Modifiers_Inversebattle:
 	msgbox gText_Modifiers_Msginverse MSG_KEEPOPEN
 	checkflag 0x900
-	if 0x0 _call EventScript_Modifiers_Flagisoff
-	if 0x1 _call EventScript_Modifiers_Flagison
+	if NOT_SET _call EventScript_Modifiers_Flagisoff
+	call EventScript_Modifiers_Flagison
 	end
 
 .global EventScript_Modifiers_Catchtrainer
 EventScript_Modifiers_Catchtrainer:
 	msgbox gText_Modifiers_Msgcatchtrainer MSG_KEEPOPEN
 	checkflag 0x905
-	if 0x0 _call EventScript_Modifiers_Flagisoff
-	if 0x1 _call EventScript_Modifiers_Flagison
+	if NOT_SET _call EventScript_Modifiers_Flagisoff
+	call EventScript_Modifiers_Flagison
 	end
 
 .global EventScript_Modifiers_Scalewild
 EventScript_Modifiers_Scalewild:
 	msgbox gText_Modifiers_Msgscalewild MSG_KEEPOPEN
 	checkflag 0x90D
-	if 0x0 _call EventScript_Modifiers_Flagisoff
-	if 0x1 _call EventScript_Modifiers_Flagison
+	if NOT_SET _call EventScript_Modifiers_Flagisoff
+	call EventScript_Modifiers_Flagison
 	end
 
 .global EventScript_Modifiers_Scaletrainer
 EventScript_Modifiers_Scaletrainer:
 	msgbox gText_Modifiers_Msgscaletrainer MSG_KEEPOPEN
 	checkflag 0x90E
-	if 0x0 _call EventScript_Modifiers_Flagisoff
-	if 0x1 _call EventScript_Modifiers_Flagison
+	if NOT_SET _call EventScript_Modifiers_Flagisoff
+	call EventScript_Modifiers_Flagison
 	end
 
 .global EventScript_Modifiers_Hiddenability
 EventScript_Modifiers_Hiddenability:
 	msgbox gText_Modifiers_Msghiddenability MSG_KEEPOPEN
 	checkflag 0x90F
-	if 0x0 _call EventScript_Modifiers_Flagisoff
-	if 0x1 _call EventScript_Modifiers_Flagison
+	if NOT_SET _call EventScript_Modifiers_Flagisoff
+	call EventScript_Modifiers_Flagison
 	end
 
 .global EventScript_Modifiers_Shiny
 EventScript_Modifiers_Shiny:
 	msgbox gText_Modifiers_Msgshiny MSG_KEEPOPEN
 	checkflag 0x913
-	if 0x0 _call EventScript_Modifiers_Flagisoff
-	if 0x1 _call EventScript_Modifiers_Flagison
+	if NOT_SET _call EventScript_Modifiers_Flagisoff
+	call EventScript_Modifiers_Flagison
 	end
 
 .global EventScript_Modifiers_Randomizer
 EventScript_Modifiers_Randomizer:
 	msgbox gText_Modifiers_Msgrandomizer MSG_KEEPOPEN
 	checkflag 0x940
-	if 0x0 _call EventScript_Modifiers_Flagisoff
-	if 0x1 _call EventScript_Modifiers_Flagison
+	if NOT_SET _call EventScript_Modifiers_Flagisoff
+	call EventScript_Modifiers_Flagison
 	end
 
 .global EventScript_Modifiers_Flagisoff

--- a/assembly/overworld_scripts/pokemart.s
+++ b/assembly/overworld_scripts/pokemart.s
@@ -1,0 +1,226 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+.include "../asm_defines.s"
+
+@ Pokemart stock is based on Gen 8 SW/SH list
+.global EventScript_Pokemart
+EventScript_Pokemart:
+    lock
+    faceplayer
+    special 0x187
+    compare LASTRESULT 0x2
+    if 0x1 _goto EventScript_End
+    msgbox gText_Pokemart_Intro MSG_KEEPOPEN
+    checkflag 0x827 @ Eight Badges
+    if SET _goto EventScript_EightBadges
+    checkflag 0x826 @ Seven Badges
+    if SET _goto EventScript_SevenBadges
+    checkflag 0x825 @ Six Badges
+    if SET _goto EventScript_SixBadges
+    checkflag 0x824 @ Five Badges
+    if SET _goto EventScript_FiveBadges
+    checkflag 0x823 @ Four Badges
+    if SET _goto EventScript_FourBadges
+    checkflag 0x822 @ Three Badges
+    if SET _goto EventScript_ThreeBadges
+    checkflag 0x821 @ Two Badges
+    if SET _goto EventScript_TwoBadges
+    checkflag 0x820 @ One Badge
+    if SET _goto EventScript_OneBadge
+    goto EventScript_NoBadges @ No badges
+
+EventScript_NoBadges:
+    pokemart NoBadges_Stock
+    goto EventScript_EndMart
+
+EventScript_OneBadge:
+    pokemart OneBadge_Stock
+    goto EventScript_EndMart
+
+EventScript_TwoBadges:
+    pokemart TwoBadges_Stock
+    goto EventScript_EndMart
+
+EventScript_ThreeBadges:
+    pokemart ThreeBadges_Stock
+    goto EventScript_EndMart
+
+EventScript_FourBadges:
+    pokemart FourBadges_Stock
+    goto EventScript_EndMart
+
+EventScript_FiveBadges:
+    pokemart FiveBadges_Stock
+    goto EventScript_EndMart
+
+EventScript_SixBadges:
+    pokemart SixBadges_Stock
+    goto EventScript_EndMart
+
+EventScript_SevenBadges:
+    pokemart SevenBadges_Stock
+    goto EventScript_EndMart
+
+EventScript_EightBadges:
+    pokemart EightBadges_Stock
+    goto EventScript_EndMart
+
+NoBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_POTION
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+OneBadge_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+TwoBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_POKE_DOLL
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+ThreeBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_POKE_DOLL
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_REPEL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+FourBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_HYPER_POTION
+    .hword ITEM_POKE_DOLL
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_REPEL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+FiveBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_ULTRA_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_HYPER_POTION
+    .hword ITEM_POKE_DOLL
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_REPEL
+    .hword ITEM_SUPER_REPEL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+SixBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_ULTRA_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_HYPER_POTION
+    .hword ITEM_POKE_DOLL
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_FULL_HEAL
+    .hword ITEM_REPEL
+    .hword ITEM_SUPER_REPEL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+SevenBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_ULTRA_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_HYPER_POTION
+    .hword ITEM_MAX_POTION
+    .hword ITEM_POKE_DOLL
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_FULL_HEAL
+    .hword ITEM_REPEL
+    .hword ITEM_SUPER_REPEL
+    .hword ITEM_MAX_REPEL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+
+EightBadges_Stock:
+    .hword ITEM_POKE_BALL
+    .hword ITEM_GREAT_BALL
+    .hword ITEM_ULTRA_BALL
+    .hword ITEM_POTION
+    .hword ITEM_SUPER_POTION
+    .hword ITEM_HYPER_POTION
+    .hword ITEM_MAX_POTION
+    .hword ITEM_FULL_RESTORE
+    .hword ITEM_POKE_DOLL
+    .hword ITEM_ANTIDOTE
+    .hword ITEM_BURN_HEAL
+    .hword ITEM_ICE_HEAL
+    .hword ITEM_AWAKENING
+    .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_FULL_HEAL
+    .hword ITEM_REPEL
+    .hword ITEM_SUPER_REPEL
+    .hword ITEM_MAX_REPEL
+    .hword ITEM_REVIVE
+    .hword ITEM_NONE
+    
+EventScript_EndMart:
+    msgbox gText_Pokemart_End MSG_NORMAL
+    goto EventScript_End
+
+EventScript_End:
+    release
+    end

--- a/assembly/overworld_scripts/rhodanzi_city/rhodanzi_trainer_school.s
+++ b/assembly/overworld_scripts/rhodanzi_city/rhodanzi_trainer_school.s
@@ -54,9 +54,9 @@ EventScript_RhodanziTrainerSchool_BasicCourse_TypeStudent:
     lock
     faceplayer
     checkflag 0x230
-    if FALSE _call EventScript_TypeStudentQuiz
+    if NOT_SET _call EventScript_TypeStudentQuiz
     checkflag 0x230
-    if TRUE _call EventScript_TypeStudentQuizComplete
+    if SET _call EventScript_TypeStudentQuizComplete
     applymovement 0x1 m_LookUp
     waitmovement ALLEVENTS
     release

--- a/eventscripts
+++ b/eventscripts
@@ -16,6 +16,9 @@
 # Prompts the player to enter their generation choice
 map 4 1 gMapScripts_GenChoice
 
+# General
+# npc 6 3 0 EventScript_Pokemart
+
 # Anthra Town
 npc 4 0 0 EventScript_AnthraTown_MomMain
 npc 3 0 0 EventScript_AnthraTown_FlowerGirl

--- a/strings/scripts/pokemart.string
+++ b/strings/scripts/pokemart.string
@@ -1,0 +1,5 @@
+#org @gText_Pokemart_Intro
+[BLACK]Welcome to our Pok\emart! How can I\nhelp you?
+
+#org @gText_Pokemart_End
+[BLACK]Please come again!


### PR DESCRIPTION
Badge based Pokemarts.  Pokemart stock changes globally as the player acquires more badges.  

The script is pretty repetitive, but I don't think there's a way to fix this... To do so, we'd need to put new items at the bottom of the list which feels gross (eg. Great Ball being way below PokeBall).

Stock is based off of Sword and Shield's behavior: https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9_Mart#Generation_VIII

Note: Players can choose to get some badges out of sequence. We won't block this or do a calculation.  If they choose to get Badge 6 before 3-4, they're rewarded with the full stock from badges 6 and down.

