### PR TITLE
Add dynamically inserted wild encounter tables

### DIFF
--- a/assembly/overworld_scripts/common/items.s
+++ b/assembly/overworld_scripts/common/items.s
@@ -1,0 +1,11 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+.include "../asm_defines.s"
+
+.global ItemScript_Common_Potion
+ItemScript_Common_Potion:
+    finditem ITEM_POTION 0x1
+    end

--- a/assembly/overworld_scripts/routes/route_17.s
+++ b/assembly/overworld_scripts/routes/route_17.s
@@ -4,6 +4,11 @@
 .include "../xse_commands.s"
 .include "../xse_defines.s"
 
+.global SignScript_Route17_CaveSign
+SignScript_Route17_CaveSign:
+    msgbox gText_Route17_CaveSign MSG_SIGN
+    end
+
 .global EventScript_Route17_Rival1
 EventScript_Route17_Rival1:
     // TODO: Fill out

--- a/eventscripts
+++ b/eventscripts
@@ -38,6 +38,10 @@ npc 1 0 1 EventScript_VarisiForest_BugCatcherBraden
 npc 1 0 2 EventScript_VarisiForest_LassBreanna
 npc 1 0 3 EventScript_VarisiForest_LassMimi
 
+# Route 17
+npc 3 35 0 ItemScript_Common_Potion
+sign 3 35 0 SignScript_Route17_CaveSign
+
 # Rhodanzi City
 ## Overworld
 map 3 2 MapScript_RhodanziOverworld_FlightSpot

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -1383,7 +1383,7 @@
 /*
 #define FLAG_WORLD_MAP_PALLET_TOWN                                  (SYS_FLAGS + 0x90)
 #define FLAG_WORLD_MAP_VIRIDIAN_CITY                                (SYS_FLAGS + 0x91)
-#define FLAG_WORLD_MAP_PEWTER_CITY                                  (SYS_FLAGS + 0x92)
+#define FLAG_WORLD_MAP_RHODANZI_CITY                                  (SYS_FLAGS + 0x92)
 #define FLAG_WORLD_MAP_CERULEAN_CITY                                (SYS_FLAGS + 0x93)
 #define FLAG_WORLD_MAP_LAVENDER_TOWN                                (SYS_FLAGS + 0x94)
 #define FLAG_WORLD_MAP_VERMILION_CITY                               (SYS_FLAGS + 0x95)
@@ -1401,7 +1401,7 @@
 #define FLAG_WORLD_MAP_SIX_ISLAND                                   (SYS_FLAGS + 0xA1)
 #define FLAG_WORLD_MAP_ROUTE4_POKEMON_CENTER_1F                     (SYS_FLAGS + 0xA2)
 #define FLAG_WORLD_MAP_ROUTE10_POKEMON_CENTER_1F                    (SYS_FLAGS + 0xA3)
-#define FLAG_WORLD_MAP_VIRIDIAN_FOREST                              (SYS_FLAGS + 0xA4)
+#define FLAG_WORLD_MAP_VARISI_FOREST                                (SYS_FLAGS + 0xA4)
 #define FLAG_WORLD_MAP_MT_MOON_1F                                   (SYS_FLAGS + 0xA5)
 #define FLAG_WORLD_MAP_SSANNE_EXTERIOR                              (SYS_FLAGS + 0xA6)
 #define FLAG_WORLD_MAP_UNDERGROUND_PATH_NORTH_SOUTH_TUNNEL          (SYS_FLAGS + 0xA7)

--- a/include/constants/maps.h
+++ b/include/constants/maps.h
@@ -23,7 +23,7 @@ u8 __attribute__((long_call)) GetCurrentRegionMapSectionId(void);
 #define MAP_UNKNOWN_MAP_00_04 (4 | (0 << 8))
 
 // Map Group 1
-#define MAP_VIRIDIAN_FOREST                      (0 | (1 << 8))
+#define MAP_VARISI_FOREST                        (0 | (1 << 8))
 #define MAP_MT_MOON_1F                           (1 | (1 << 8))
 #define MAP_MT_MOON_B1F                          (2 | (1 << 8))
 #define MAP_MT_MOON_B2F                          (3 | (1 << 8))
@@ -212,7 +212,7 @@ u8 __attribute__((long_call)) GetCurrentRegionMapSectionId(void);
 // Map Group 3
 #define MAP_PALLET_TOWN                          (0 | (3 << 8))
 #define MAP_VIRIDIAN_CITY                        (1 | (3 << 8))
-#define MAP_PEWTER_CITY                          (2 | (3 << 8))
+#define MAP_RHODANZI_CITY                        (2 | (3 << 8))
 #define MAP_CERULEAN_CITY                        (3 | (3 << 8))
 #define MAP_LAVENDER_TOWN                        (4 | (3 << 8))
 #define MAP_VERMILION_CITY                       (5 | (3 << 8))
@@ -451,7 +451,7 @@ u8 __attribute__((long_call)) GetCurrentRegionMapSectionId(void);
 #define MAP_UNUSED_HOUSE_29_00 (0 | (29 << 8))
 
 // Map Group 30
-#define MAP_ROUTE25_SEA_COTTAGE (0 | (30 << 8))
+#define MAP_ROUTE17_CAVE_1F (0 | (30 << 8))
 
 // Map Group 31
 #define MAP_SEVEN_ISLAND_HOUSE_ROOM1       (0 | (31 << 8))

--- a/src/Tables/wild_encounter_tables.c
+++ b/src/Tables/wild_encounter_tables.c
@@ -19,6 +19,248 @@ tables to edit:
 
 #ifndef UNBOUND //Modify this section
 
+// #region Route structs
+const struct WildPokemon gRoute1_LandMons[] =
+{
+	{2, 3, SPECIES_BIDOOF},
+	{2, 3, SPECIES_WINGULL},
+	{2, 4, SPECIES_BIDOOF},
+	{2, 4, SPECIES_WINGULL},
+	{2, 3, SPECIES_SUNKERN},
+	{2, 3, SPECIES_SUNKERN},
+	{2, 4, SPECIES_YAMPER},
+	{2, 4, SPECIES_YAMPER},
+	{3, 4, SPECIES_BIDOOF},
+	{3, 4, SPECIES_WINGULL},
+	{4, 4, SPECIES_BIDOOF},
+	{4, 4, SPECIES_WINGULL},
+};
+
+const struct WildPokemon gRoute1_FishingMons[] = 
+{
+	{8, 10, SPECIES_MAGIKARP}, 	// Old Rod
+	{8, 11, SPECIES_MAGIKARP}, 	// Old Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+};
+
+const struct WildPokemon gRoute2_LandMons[] =
+{
+	{3, 5, SPECIES_BUDEW},
+	{2, 4, SPECIES_GRUBBIN},
+	{3, 6, SPECIES_ROCKRUFF},
+	{2, 6, SPECIES_NICKIT},
+	{3, 6, SPECIES_NIDORAN_M},
+	{3, 5, SPECIES_ROOKIDEE},
+	{2, 5, SPECIES_NICKIT},
+	{3, 6, SPECIES_NIDORAN_M},
+	{2, 4, SPECIES_ROCKRUFF},
+	{3, 5, SPECIES_ROOKIDEE},
+	{3, 5, SPECIES_ROCKRUFF},
+	{3, 5, SPECIES_ROOKIDEE},
+};
+
+const struct WildPokemon gRoute2_FishingMons[] = 
+{
+	{8, 10, SPECIES_MAGIKARP}, 	// Old Rod
+	{8, 11, SPECIES_MAGIKARP}, 	// Old Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+};
+
+const struct WildPokemon gRoute17_LandMons[] =
+{
+	{2, 3, SPECIES_FLABEBE},
+	{2, 4, SPECIES_FLETCHLING},
+	{2, 3, SPECIES_RALTS},
+	{3, 4, SPECIES_RALTS},
+	{2, 3, SPECIES_FLETCHLING},
+	{2, 4, SPECIES_CUTIEFLY},
+	{2, 3, SPECIES_CUTIEFLY},
+	{2, 3, SPECIES_GRUBBIN},
+	{2, 4, SPECIES_GRUBBIN},
+	{2, 4, SPECIES_FLABEBE},
+	{3, 3, SPECIES_GRUBBIN},
+	{3, 3, SPECIES_FLABEBE},
+};
+
+const struct WildPokemon gRoute17_Cave1F_LandMons[] =
+{
+	{3, 4, SPECIES_DRILBUR},
+	{3, 3, SPECIES_DRILBUR},
+	{2, 3, SPECIES_ZUBAT},
+	{3, 3, SPECIES_ZUBAT},
+	{2, 4, SPECIES_ROGGENROLA},
+	{3, 4, SPECIES_BONSLY},
+	{2, 4, SPECIES_ZUBAT},
+	{3, 4, SPECIES_NOIBAT},
+	{3, 4, SPECIES_ZUBAT},
+	{3, 4, SPECIES_ROGGENROLA},
+	{2, 4, SPECIES_ZUBAT},
+	{2, 4, SPECIES_ROGGENROLA},
+};
+
+const struct WildPokemon gRoute17_FishingMons[] = 
+{
+	{8, 10, SPECIES_MAGIKARP}, 	// Old Rod
+	{8, 11, SPECIES_MAGIKARP}, 	// Old Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Good Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+	{1, 1, SPECIES_NONE},		// Super Rod
+};
+
+// #endregion
+
+// #region Dungeon Structs
+const struct WildPokemon gVarisiForest_LandMons[] =
+{
+	{3, 6, SPECIES_BLIPBUG},
+	{3, 6, SPECIES_PIKIPEK},
+	{3, 7, SPECIES_MORELULL},
+	{2, 6, SPECIES_PICHU},
+	{3, 6, SPECIES_BUNEARY},
+	{3, 7, SPECIES_SHROOMISH},
+	{3, 7, SPECIES_BUDEW},
+	{4, 7, SPECIES_BONSLY},
+	{3, 6, SPECIES_VENIPEDE},
+	{3, 7, SPECIES_VENIPEDE},
+	{4, 6, SPECIES_SLAKOTH},
+	{4, 7, SPECIES_SLAKOTH},
+};
+
+const struct WildPokemon gVarisiForest_LandMonsNight[] =
+{
+	{3, 6, SPECIES_BLIPBUG},
+	{3, 6, SPECIES_HOOTHOOT},
+	{3, 7, SPECIES_MORELULL},
+	{2, 6, SPECIES_PICHU},
+	{3, 6, SPECIES_BUNEARY},
+	{3, 7, SPECIES_SHROOMISH},
+	{3, 7, SPECIES_BUDEW},
+	{4, 7, SPECIES_BONSLY},
+	{3, 6, SPECIES_VENIPEDE},
+	{3, 7, SPECIES_VENIPEDE},
+	{4, 6, SPECIES_SLAKOTH},
+	{4, 7, SPECIES_SLAKOTH},
+};
+// #endregion
+
+// #region Town Structs
+const struct WildPokemon gRhodanziCity_WaterMons[] =
+{
+	{5, 15, SPECIES_CHINCHOU},
+	{5, 20, SPECIES_CHINCHOU},
+	{20, 35, SPECIES_LANTURN},
+	{10, 30, SPECIES_CHINCHOU},
+	{10, 30, SPECIES_CHINCHOU},
+};
+
+const struct WildPokemon gRhodanziCity_FishingMons[] = 
+{
+	{3, 7, SPECIES_MAGIKARP}, 		// Old Rod
+	{4, 8, SPECIES_CORPHISH}, 		// Old Rod
+	{20, 25, SPECIES_CORPHISH},		// Good Rod
+	{20, 25, SPECIES_MAGIKARP},		// Good Rod
+	{19, 26, SPECIES_MAGIKARP},		// Good Rod
+	{35, 40, SPECIES_GYARADOS},		// Super Rod
+	{33, 41, SPECIES_CRAWDAUNT},	// Super Rod
+	{35, 40, SPECIES_SLOWPOKE},		// Super Rod
+	{36, 42, SPECIES_SLOWPOKE},		// Super Rod
+	{38, 44, SPECIES_SLOWBRO},		// Super Rod
+};
+// #endregion
+
+// #region Encounter Rate Structs
+const struct WildPokemonInfo gRoute1_LandMonsInfo = {21, gRoute1_LandMons};
+const struct WildPokemonInfo gRoute1_FishingMonsInfo = {20, gRoute1_FishingMons};
+const struct WildPokemonInfo gRoute2_LandMonsInfo = {21, gRoute2_LandMons};
+const struct WildPokemonInfo gRoute2_FishingMonsInfo = {20, gRoute2_FishingMons};
+const struct WildPokemonInfo gRoute17_LandMonsInfo = {21, gRoute17_LandMons};
+const struct WildPokemonInfo gRoute17_Cave1F_LandMonsInfo = {21, gRoute17_Cave1F_LandMons};
+const struct WildPokemonInfo gRoute17_FishingMonsInfo = {20, gRoute17_FishingMons};
+const struct WildPokemonInfo gVarisiForest_LandMonsInfo = {21, gVarisiForest_LandMons};
+const struct WildPokemonInfo gVarisiForest_LandMonsNightInfo = {21, gVarisiForest_LandMonsNight};
+const struct WildPokemonInfo gRhodanziCity_WaterMonsInfo = {21, gRhodanziCity_WaterMons};
+const struct WildPokemonInfo gRhodanziCity_FishingMonsInfo = {20, gRhodanziCity_FishingMons};
+// #endregion
+
+const struct WildPokemonHeader gWildMonRegularHeaders[] =
+{
+	{
+		.mapGroup = MAP_GROUP(ROUTE_1),
+		.mapNum = MAP_NUM(ROUTE_1),
+		.landMonsInfo = &gRoute1_LandMonsInfo,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = &gRoute1_FishingMonsInfo,
+	},
+	{
+		.mapGroup = MAP_GROUP(ROUTE_2),
+		.mapNum = MAP_NUM(ROUTE_2),
+		.landMonsInfo = &gRoute2_LandMonsInfo,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = &gRoute2_FishingMonsInfo,
+	},
+	{
+		.mapGroup = MAP_GROUP(ROUTE_17),
+		.mapNum = MAP_NUM(ROUTE_17),
+		.landMonsInfo = &gRoute17_LandMonsInfo,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = &gRoute17_FishingMonsInfo,
+	},
+	{
+		.mapGroup = MAP_GROUP(ROUTE17_CAVE_1F),
+		.mapNum = MAP_NUM(ROUTE17_CAVE_1F),
+		.landMonsInfo = &gRoute17_Cave1F_LandMonsInfo,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = NULL,
+	},
+	{
+		.mapGroup = MAP_GROUP(VARISI_FOREST),
+		.mapNum = MAP_NUM(VARISI_FOREST),
+		.landMonsInfo = &gVarisiForest_LandMonsInfo,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = NULL,
+	},
+	{
+		.mapGroup = MAP_GROUP(RHODANZI_CITY),
+		.mapNum = MAP_NUM(RHODANZI_CITY),
+		.landMonsInfo = NULL,
+		.waterMonsInfo = &gRhodanziCity_WaterMonsInfo,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = &gRhodanziCity_FishingMonsInfo,
+	},
+	{
+		.mapGroup = 0xFF,
+		.mapNum = 0xFF,
+		.landMonsInfo = NULL,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = NULL,
+	}
+};
+
 const struct WildPokemonHeader gWildMonMorningHeaders[] =
 {
 	{
@@ -45,6 +287,14 @@ const struct WildPokemonHeader gWildMonEveningHeaders[] =
 
 const struct WildPokemonHeader gWildMonNightHeaders[] =
 {
+	{
+		.mapGroup = MAP_GROUP(VARISI_FOREST),
+		.mapNum = MAP_NUM(VARISI_FOREST),
+		.landMonsInfo = &gVarisiForest_LandMonsNightInfo,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = NULL,
+	},
 	{
 		.mapGroup = 0xFF,
 		.mapNum = 0xFF,

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -51,6 +51,7 @@ extern u8 sSavedWildDataMapNum;
 extern struct EncounterRate sWildEncounterData;
 
 extern u8 sUnownLetterSlots[NUM_TANOBY_CHAMBERS][12]; //[NUM_ROOMS][NUM_WILD_INDEXES]
+extern const struct WildPokemonHeader gWildMonRegularHeaders[];
 extern const struct WildPokemonHeader gWildMonMorningHeaders[];
 extern const struct WildPokemonHeader gWildMonEveningHeaders[];
 extern const struct WildPokemonHeader gWildMonNightHeaders[];
@@ -161,7 +162,8 @@ static const struct WildPokemonHeader* GetCurrentMapWildMonHeader(void)
 	#ifdef TIME_ENABLED
 		u32 i;
 
-		const struct WildPokemonHeader* headerTable = NULL;
+		// Set default encounter table
+		const struct WildPokemonHeader* headerTable = gWildMonRegularHeaders;
 
 		if (IsNightTime())
 			headerTable = gWildMonNightHeaders;
@@ -170,17 +172,24 @@ static const struct WildPokemonHeader* GetCurrentMapWildMonHeader(void)
 		else if (IsEvening())
 			headerTable = gWildMonEveningHeaders;
 
-		if (headerTable != NULL) //Not Daytime
+		// Search the time of day table
+		for (i = 0; headerTable[i].mapGroup != 0xFF; ++i)
 		{
-			for (i = 0; headerTable[i].mapGroup != 0xFF; ++i)
-			{
-				if (headerTable[i].mapGroup == gSaveBlock1->location.mapGroup
-				&&  headerTable[i].mapNum == gSaveBlock1->location.mapNum)
-					return &headerTable[i];
-			}
+			if (headerTable[i].mapGroup == gSaveBlock1->location.mapGroup
+			&&  headerTable[i].mapNum == gSaveBlock1->location.mapNum)
+				return &headerTable[i];
 		}
 	#endif
 
+	// If not found, or time is disabled, search in the regular table
+	for (i = 0; gWildMonRegularHeaders[i].mapGroup != 0xFF; ++i)
+	{
+		if (gWildMonRegularHeaders[i].mapGroup == gSaveBlock1->location.mapGroup
+		&&  gWildMonRegularHeaders[i].mapNum == gSaveBlock1->location.mapNum)
+			return &gWildMonRegularHeaders[i];
+	}
+
+	// Default to binary content
 	return GetCurrentMapWildMonDaytimeHeader();
 }
 

--- a/strings/scripts/routes/route_17.string
+++ b/strings/scripts/routes/route_17.string
@@ -1,0 +1,2 @@
+#org @gText_Route17_CaveSign
+Danger! Wild Pokemon have been\nsighted. Please be careful.


### PR DESCRIPTION
Dynamically insert wild encounter tables.

**NOTE:** We may choose to revert this someday.  This is a workaround so we don't need to insert DPE ahead of time in order to define wild encounters.