### PR TITLE
Add NPCs to Varisi Forest, update evening encounter

### DIFF
--- a/assembly/overworld_scripts/dungeons/varisi_forest.s
+++ b/assembly/overworld_scripts/dungeons/varisi_forest.s
@@ -3,6 +3,7 @@
 
 .include "../xse_commands.s"
 .include "../xse_defines.s"
+.include "../asm_defines.s"
 
 .global EventScript_VarisiForest_BugCatcherKendell
 EventScript_VarisiForest_BugCatcherKendell:
@@ -26,4 +27,45 @@ EventScript_VarisiForest_LassBreanna:
 EventScript_VarisiForest_LassMimi:
     trainerbattle0 0x0 0xb 0x0 gText_VarisiForest_LassMimi_Intro gText_VarisiForest_LassMimi_Defeat
     msgbox gText_VarisiForest_LassMimi_Chat MSG_NORMAL
+    end
+
+.global EventScript_VarisiForest_TrainerTip
+EventScript_VarisiForest_TrainerTip:
+    npcchat gText_VarisiForest_TrainerTip
+    end
+
+.global EventScript_VarisiForest_PoisonWarning
+EventScript_VarisiForest_PoisonWarning:
+    lock
+    faceplayer
+    msgbox gText_VarisiForest_PoisonWarning MSG_NORMAL
+    checkflag 0x230 @ Has received Antidote gift
+    if NOT_SET _goto EventScript_VarisiForest_AntidoteGift
+    goto EventScript_VarisiForest_PoisonWarningEnd
+
+EventScript_VarisiForest_AntidoteGift:
+    msgbox gText_VarisiForest_AntidoteGift MSG_NORMAL
+    obtainitem ITEM_ANTIDOTE 0x1
+    setflag 0x230 @ Has received Antidote gift
+    goto EventScript_VarisiForest_PoisonWarningEnd
+    
+EventScript_VarisiForest_PoisonWarningEnd:
+    applymovement 0x1 m_LookRight
+	waitmovement ALLEVENTS
+    release
+    end
+
+.global EventScript_VarisiForest_SurprisedTrainer
+EventScript_VarisiForest_SurprisedTrainer:
+    npcchat gText_VarisiForest_SurprisedTrainer
+    end
+
+.global EventScript_VarisiForest_TimeOfDay
+EventScript_VarisiForest_TimeOfDay:
+    npcchat2 0x1 m_LookRight gText_VarisiForest_TimeOfDay
+    end
+
+.global EventScript_VarisiForest_FriendlyTrainer
+EventScript_VarisiForest_FriendlyTrainer:
+    npcchat2 0x2 m_LookUp gText_VarisiForest_FriendlyTrainer
     end

--- a/eventscripts
+++ b/eventscripts
@@ -37,6 +37,11 @@ npc 1 0 0 EventScript_VarisiForest_BugCatcherKendell
 npc 1 0 1 EventScript_VarisiForest_BugCatcherBraden
 npc 1 0 2 EventScript_VarisiForest_LassBreanna
 npc 1 0 3 EventScript_VarisiForest_LassMimi
+npc 15 0 0 EventScript_VarisiForest_PoisonWarning
+npc 15 0 1 EventScript_VarisiForest_TrainerTip
+npc 15 2 0 EventScript_VarisiForest_SurprisedTrainer
+npc 15 3 0 EventScript_VarisiForest_TimeOfDay
+npc 15 3 1 EventScript_VarisiForest_FriendlyTrainer
 
 # Route 17
 npc 3 35 0 ItemScript_Common_Potion

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -575,7 +575,7 @@
 /*
 #define STORY_FLAGS_START 0x230
 #define FLAG_COMPLETED_TYPE_TRAINER_QUIZ                 0x230
-#define FLAG_GOT_TM34_FROM_SURGE                         0x231
+#define FLAG_RECEIVED_ANTIDOTE_GIFT                      0x231
 #define FLAG_GOT_FOSSIL_FROM_MT_MOON                     0x232
 #define FLAG_HELPED_BILL_IN_SEA_COTTAGE                  0x233
 #define FLAG_GOT_SS_TICKET                               0x234

--- a/src/Tables/wild_encounter_tables.c
+++ b/src/Tables/wild_encounter_tables.c
@@ -276,6 +276,14 @@ const struct WildPokemonHeader gWildMonMorningHeaders[] =
 const struct WildPokemonHeader gWildMonEveningHeaders[] =
 {
 	{
+		.mapGroup = MAP_GROUP(VARISI_FOREST),
+		.mapNum = MAP_NUM(VARISI_FOREST),
+		.landMonsInfo = &gVarisiForest_LandMonsNightInfo,
+		.waterMonsInfo = NULL,
+		.rockSmashMonsInfo = NULL,
+		.fishingMonsInfo = NULL,
+	},
+	{
 		.mapGroup = 0xFF,
 		.mapNum = 0xFF,
 		.landMonsInfo = NULL,

--- a/strings/scripts/dungeons/varisi_forest.string
+++ b/strings/scripts/dungeons/varisi_forest.string
@@ -33,3 +33,21 @@ Well, it was peaceful[.]
 
 #org @gText_VarisiForest_LassMimi_Chat
 I love coming here to listen to the\nbirds, don't you?
+
+#org @gText_VarisiForest_TrainerTip
+If you lock eyes with a Trainer,\nyou'll have to battle them.\pMake sure you're prepared before\ngoing out!
+
+#org @gText_VarisiForest_PoisonWarning
+Some Pok\emon in Varisi Forest can\npoison your Pok\emon. Bring\lantidotes before going in there!
+
+#org @gText_VarisiForest_AntidoteGift
+Here, I have a spare. Take it!
+
+#org @gText_VarisiForest_SurprisedTrainer
+I'm surprised to see you here.\nMost trainers don't come this way.\pTheir loss though!\nIt's a nice shortcut.
+
+#org @gText_VarisiForest_TimeOfDay
+Some Pok\emon only appear during\ncertain times of day.\pFor example, you'll only find\nPikipek in Varisi Forest during the\lday.
+
+#org @gText_VarisiForest_FriendlyTrainer
+Oh, you're going on an adventure with\nyour friend? How nice! Make sure\lyou enjoy it.


### PR DESCRIPTION
Adds friendly NPCs to Varisi Forest.
Also matches the Varisi Forest evening (6pm-10pm) and night (10pm-6am) tables so players are more likely to encounter HootHoot.