### PR TITLE
Add Rhodanzi Gym events

### DIFF
--- a/assembly/overworld_scripts/rhodanzi_city/rhodanzi_gym.s
+++ b/assembly/overworld_scripts/rhodanzi_city/rhodanzi_gym.s
@@ -3,10 +3,38 @@
 
 .include "../xse_commands.s"
 .include "../xse_defines.s"
+.include "../asm_defines.s"
+
+.global SignScript_RhodanziGym_Placard
+SignScript_RhodanziGym_Placard:
+    lockall
+    checkflag 0x820 @ Rhodanzi gym badge
+    if SET _goto SignScript_RhodanziGym_PlacardWithBadge
+    checkflag 0x232 @ DexNav event triggered
+    if SET _goto SignScript_RhodanziGym_PlacardWithBadgeAndDexNavEvent
+    msgbox gText_RhodanziGym_Winners MSG_SIGN
+    releaseall
+    end
+
+SignScript_RhodanziGym_PlacardWithBadge:
+    msgbox gText_RhodanziGym_WinnersWithBadge MSG_SIGN
+    releaseall
+    end
+
+SignScript_RhodanziGym_PlacardWithBadgeAndDexNavEvent:
+    msgbox gText_RhodanziGym_WinnersWithBadgeAndDexNavEvent MSG_SIGN
+    releaseall
+    end
 
 .global EventScript_RhodanziGym_GymExpert
 EventScript_RhodanziGym_GymExpert:
-    // TODO: Fill out
+    checkflag 0x820 @ Rhodanzi gym badge
+    if SET _goto EventScript_RhodanziGym_GymExpertBadgeObtained
+    npcchat gText_RhodanziGym_ExpertTips
+    end
+
+EventScript_RhodanziGym_GymExpertBadgeObtained:
+    npcchat gText_RhodanziGym_ExpertBadgeObtained
     end
 
 .global EventScript_RhodanziGym_Alonso
@@ -23,7 +51,32 @@ EventScript_RhodanziGym_Brandon:
 
 .global EventScript_RhodanziGym_Leader_Terrence
 EventScript_RhodanziGym_Leader_Terrence:
-    // TODO: Flesh Terrence out more; he's a normal encounter at the moment
-    trainerbattle0 0x0 0xE 0x0 gText_RhodanziGym_Leader_Terrence_Intro gText_RhodanziGym_Leader_Terrence_Defeat
-    msgbox gText_RhodanziGym_Leader_Terrence_Chat MSG_NORMAL
+    lockall
+    faceplayer
+    checkflag 0x820 @ Rhodanzi gym badge
+    if SET _goto EventScript_RhodanziGym_Leader_TerrenceChat
+    msgbox gText_RhodanziGym_Leader_Terrence_Talk MSG_NORMAL
+    setvar 0x503A 0x1
+    setvar 0x503B 0x1
+    trainerbattle1 0x1 0xE 0x100 gText_RhodanziGym_Leader_Terrence_Intro gText_RhodanziGym_Leader_Terrence_Defeat EventScript_RhodanziGym_Leader_TerrenceDefeated
+    end
+
+EventScript_RhodanziGym_Leader_TerrenceDefeated:
+    msgbox gText_RhodanziGym_Leader_Terrence_BadgeAwarded MSG_NORMAL
+    playfanfare 0x138 @ Gym victory
+    msgbox gText_RhodanziGym_BadgeReceived MSG_NORMAL
+    setflag 0x820 @ Rhodanzi gym badge
+    settrainerflag 0xC @ Alonso cannot be battled now
+    settrainerflag 0xD @ Brandon cannot be battled now
+    msgbox gText_RhodanziGym_Leader_Terrence_BadgeDescription MSG_NORMAL
+    msgbox gText_RhodanziGym_Leader_Terrence_TMReceived MSG_NORMAL
+    loadpointer 0x0 gText_RhodanziGym_BadgeReceived
+    additem ITEM_TM05 0x1
+    giveitemwithfanfare ITEM_TM05 0x1 0x101 @ MUS_FANFA1
+    setflag 0x254 @ Received TM 05 from Terrence
+    release
+    end
+
+EventScript_RhodanziGym_Leader_TerrenceChat:
+    npcchat gText_RhodanziGym_Leader_Terrence_Chat
     end

--- a/eventscripts
+++ b/eventscripts
@@ -115,6 +115,8 @@ npc 6 5 2 EventScript_RhodanziFacilities_Center_Trade
 npc 6 5 3 EventScript_RhodanziFacilities_Center_PokemonTreatment
 
 ## Gym
+sign 6 6 0 SignScript_RhodanziGym_Placard
+sign 6 6 1 SignScript_RhodanziGym_Placard
 npc 6 6 0 EventScript_RhodanziGym_GymExpert
 npc 6 6 1 EventScript_RhodanziGym_Alonso
 npc 6 6 2 EventScript_RhodanziGym_Brandon

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -576,7 +576,7 @@
 #define STORY_FLAGS_START 0x230
 #define FLAG_COMPLETED_TYPE_TRAINER_QUIZ                 0x230
 #define FLAG_RECEIVED_ANTIDOTE_GIFT                      0x231
-#define FLAG_GOT_FOSSIL_FROM_MT_MOON                     0x232
+#define FLAG_INITIATED_DEXNAV_EVENT                      0x232
 #define FLAG_HELPED_BILL_IN_SEA_COTTAGE                  0x233
 #define FLAG_GOT_SS_TICKET                               0x234
 #define FLAG_GOT_SS_TICKET_DUP                           0x235
@@ -610,7 +610,7 @@
 #define FLAG_DID_NINA_TRADE                              0x251
 #define FLAG_GOT_ITEMFINDER                              0x252
 #define FLAG_WOKE_UP_ROUTE_12_SNORLAX                    0x253
-#define FLAG_GOT_TM39_FROM_BROCK                         0x254
+#define FLAG_GOT_TM05_FROM_TERRENCE                      0x254
 #define FLAG_GOT_SUPER_ROD                               0x255
 #define FLAG_GOT_EXP_SHARE_FROM_OAKS_AIDE                0x256
 #define FLAG_DID_MARC_TRADE                              0x257

--- a/strings/scripts/rhodanzi_city/rhodanzi_gym.string
+++ b/strings/scripts/rhodanzi_city/rhodanzi_gym.string
@@ -1,3 +1,18 @@
+#org @gText_RhodanziGym_Winners
+Rhodanzi City Gym\nVictors:
+
+#org @gText_RhodanziGym_WinnersWithBadge
+Rhodanzi City Gym\nVictors: [PLAYER]
+
+#org @gText_RhodanziGym_WinnersWithBadgeAndDexNavEvent
+Rhodanzi City Gym\nVictors: [PLAYER], [RIVAL]
+
+#org @gText_RhodanziGym_ExpertTips
+Yo, superstar, welcome to the\nRhodanzi City gym!\pAll trainers in this gym specialize\nin a different type of terrain\lmove. Pay close attention to come\lout on top.\pGym leader Terrence uses grass\ntypes and grassy terrain. I suggest\lbringing a fire, flying, bug, or\lpoison type Pok\emon.\pYou've got this! Shoot for the stars,\nchamp. I'll be rooting for you.
+
+#org @gText_RhodanziGym_ExpertBadgeObtained
+Superstar, you've done it!\nCongratulations! Continue your\ljourney, and we'll meet again soon.
+
 #org @gText_RhodanziGym_Alonso_Intro
 You're a hundred - no, a thousand -\nyears too inexperienced to face\lTerrence!
 
@@ -16,11 +31,30 @@ Even with my Electric Terrain, I\nstill lost!
 #org @gText_RhodanziGym_Brandon_Chat
 Each terrain does something\ndifferent.\pElectric Terrain strengthens\nelectric type moves and makes it so\lPok\emon can't fall asleep, for\lexample.
 
+#org @gText_RhodanziGym_Leader_Terrence_Talk
+Welcome, trainer. I am Terrence, the\nleader of the Rhodanzi Gym. I'll\lbe your first roadblock on the\lKulure gym challenge.\pBelieve in your Pok\emon and do your\nbest, and you'll do great.
+
 #org @gText_RhodanziGym_Leader_Terrence_Intro
-Placeholder
+[BLUE]Now, let's begin!
 
 #org @gText_RhodanziGym_Leader_Terrence_Defeat
 Excellent! Well done, [PLAYER].
 
 #org @gText_RhodanziGym_Leader_Terrence_Chat
-Placeholder
+You battled well, [PLAYER].\pYour gym challenge will take you\nto Ferrox Village in the east.\pBelieve in your Pok\emon and never\ngive up!\pI expect great things from you.
+
+#org @gText_RhodanziGym_Leader_Terrence_BadgeAwarded
+[BLUE]Congratulations! You battled well,\nand have earned the Terrain Badge.\lPlease, take it.
+
+#org @gText_RhodanziGym_BadgeReceived
+[PLAYER] received the Terrain Badge!
+
+#org @gText_RhodanziGym_TMReceived
+[PLAYER] received TM05 from Terrence!
+
+#org @gText_RhodanziGym_Leader_Terrence_BadgeDescription
+[BLUE]This badge is proof of your\nvictory over me, and your\lcapabilities as a trainer.\lAll Pok\emon up to level 25 will\lnow obey you without fail.
+
+#org @gText_RhodanziGym_Leader_Terrence_TMReceived
+[BLUE]I will also give you TM05, which\ncontains Terrain Pulse. It can be\ltaught to your Pok\emon as many\ltimes as you'd like.\pI'd suggest visiting the terrain tutor\nat Rhodanzi Trainer school to make\lthe most of it.
+


### PR DESCRIPTION
Adds events to Rhodanzi Gym for the victory placards, gym expert, and leader Terrence.

**Behaviors:**
**Placard:**
- Shows no victors at first
- Shows player after beating Terrence
- Shows player and rival after initiating dexnav event (in next milestone)

**Gym expert:**
- Gives tips before beating Terrence
- Congratulates player after beating Terrence

**Terrence:**
- Initiates gym leader style battle, complete with mugshot
- After battle, awards Terrain badge & gives TM05, flags are set
- Sets gym trainers as battled, so they can't be challenged after