### PR TITLE
Rubarr desert caves

### DIFF
--- a/assembly/debug/debug_mode.s
+++ b/assembly/debug/debug_mode.s
@@ -34,3 +34,4 @@ EventScript_DebugMode_Main:
 	setvar LASTRESULT 0x5
 	callasm DebugMenu_ProcessGiveItem
 	AddItem ITEM_RARE_CANDY 0x32
+	end

--- a/assembly/overworld_scripts/common/hms.s
+++ b/assembly/overworld_scripts/common/hms.s
@@ -36,7 +36,7 @@ EventScript_Common_CutFillerText:
     goto ReleaseAll
 
 EventScript_Common_CutTree:
-    applymovement LASTTALKED 0x81BDF85 @ Cut animation
+    applymovement LASTTALKED m_CutTree
     waitmovement ALLEVENTS
     hidesprite LASTTALKED
     goto ReleaseAll
@@ -64,15 +64,15 @@ EventScript_Common_RockFillerText:
     goto ReleaseAll
 
 EventScript_Common_SmashRock:
-    @ TODO: Not working properly...
-    applymovement LASTTALKED 0x81BE08F @ Rock Smash animation
+    applymovement LASTTALKED m_SmashRock
     waitmovement ALLEVENTS
     hidesprite LASTTALKED
+    special 0xAB
+    waitstate
     goto ReleaseAll
 
 .global EventScript_Common_Strength
 EventScript_Common_Strength:
-    @ TODO: Not working properly...
     checkflag 0x805
     if SET _goto ReleaseAll
     lockall
@@ -89,6 +89,7 @@ EventScript_Common_Strength:
     doanimation 0x28
     waitstate
     setflag 0x805 @ Can now push boulders while on this map
+    goto ReleaseAll
 
 EventScript_Common_StrengthFillerText:
     msgbox gText_Common_PushableRock MSG_SIGN
@@ -97,3 +98,6 @@ EventScript_Common_StrengthFillerText:
 ReleaseAll:
     releaseall
     end
+
+m_CutTree: .byte cut_tree, end_m
+m_SmashRock: .byte smash_rock, end_m

--- a/assembly/overworld_scripts/common/items.s
+++ b/assembly/overworld_scripts/common/items.s
@@ -56,6 +56,11 @@ ItemScript_Common_SoftSand:
     finditem ITEM_SOFT_SAND 0x1
     end
 
+.global ItemScript_Common_FocusSash
+ItemScript_Common_FocusSash:
+    finditem ITEM_FOCUS_SASH 0x1
+    end
+
 .global ItemScript_Common_ChoiceScarf
 ItemScript_Common_ChoiceScarf:
     finditem ITEM_CHOICE_SCARF 0x1

--- a/assembly/overworld_scripts/dungeons/rubarr_desert.s
+++ b/assembly/overworld_scripts/dungeons/rubarr_desert.s
@@ -81,6 +81,21 @@ EventScript_RubarrDesert_TMFlameCharge:
     call ItemScript_Common_FindTM
     end
 
+.global EventScript_RubarrDesert_CaveGuide
+EventScript_RubarrDesert_CaveGuide:
+    faceplayer
+    lockall    
+    msgbox gText_RubarrDesert_TourGuideIntro MSG_YESNO
+    compare LASTRESULT YES
+    if true _call EventScript_RubarrDesert_CaveGuide_Info
+    msgbox gText_RubarrDesert_TourGuideFarewell MSG_NORMAL
+    release
+    end
+
+EventScript_RubarrDesert_CaveGuide_Info:
+    msgbox gText_RubarrDesert_TourGuideDetails MSG_NORMAL
+    return
+
 .global SignScript_RubarrDesert_Oasis
 SignScript_RubarrDesert_Oasis:
     msgbox gText_RubarrDesert_OasisSign MSG_SIGN

--- a/assembly/overworld_scripts/dungeons/rubarr_desert.s
+++ b/assembly/overworld_scripts/dungeons/rubarr_desert.s
@@ -81,3 +81,7 @@ EventScript_RubarrDesert_TMFlameCharge:
     call ItemScript_Common_FindTM
     end
 
+.global SignScript_RubarrDesert_Oasis
+SignScript_RubarrDesert_Oasis:
+    msgbox gText_RubarrDesert_OasisSign MSG_SIGN
+    end

--- a/automation/WildEncounters.json
+++ b/automation/WildEncounters.json
@@ -68,6 +68,68 @@
             }
         },
         {
+            "mapgroup": 1,
+            "mapnum": 2,
+            "grass": {
+                "rate": 5,
+                "pokemon": [
+                    { "low": 28, "high": 34, "species": "SPECIES_ZUBAT" },
+                    { "low": 27, "high": 35, "species": "SPECIES_TRAPINCH" },
+                    { "low": 29, "high": 35, "species": "SPECIES_SANDILE" },
+                    { "low": 31, "high": 34, "species": "SPECIES_ZUBAT" },
+                    { "low": 29, "high": 36, "species": "SPECIES_KROKOROK" },
+                    { "low": 35, "high": 35, "species": "SPECIES_VIBRAVA" },
+                    { "low": 27, "high": 34, "species": "SPECIES_TRAPINCH" },
+                    { "low": 30, "high": 33, "species": "SPECIES_KROKOROK" },
+                    { "low": 31, "high": 36, "species": "SPECIES_GOLBAT" },
+                    { "low": 33, "high": 38, "species": "SPECIES_KROKOROK" },
+                    { "low": 32, "high": 37, "species": "SPECIES_GOLBAT" }, 
+                    { "low": 29, "high": 33, "species": "SPECIES_TRAPINCH" }
+                ]
+            },
+            "rocks": {
+                "rate": 50,
+                "pokemon": [
+                    { "low": 25, "high": 35, "species": "SPECIES_BOLDORE" },
+                    { "low": 23, "high": 35, "species": "SPECIES_CARKOL" },
+                    { "low": 27, "high": 37, "species": "SPECIES_BOLDORE" },
+                    { "low": 30, "high": 37, "species": "SPECIES_CARBINK" },
+                    { "low": 33, "high": 38, "species": "SPECIES_BOLDORE" }
+                ]
+            }
+        },
+        {
+            "mapgroup": 1,
+            "mapnum": 3,
+            "grass": {
+                "rate": 5,
+                "pokemon": [
+                    { "low": 37, "high": 41, "species": "SPECIES_GOLBAT" },
+                    { "low": 38, "high": 42, "species": "SPECIES_TRAPINCH" },
+                    { "low": 36, "high": 40, "species": "SPECIES_KROKOROK" },
+                    { "low": 37, "high": 42, "species": "SPECIES_GOLBAT" },
+                    { "low": 36, "high": 43, "species": "SPECIES_NOIBAT" },
+                    { "low": 38, "high": 42, "species": "SPECIES_EXCADRILL" },
+                    { "low": 39, "high": 44, "species": "SPECIES_VIBRAVA" },
+                    { "low": 45, "high": 45, "species": "SPECIES_FLYGON" },
+                    { "low": 40, "high": 42, "species": "SPECIES_KROOKODILE" },
+                    { "low": 38, "high": 41, "species": "SPECIES_VIBRAVA" },
+                    { "low": 39, "high": 43, "species": "SPECIES_NOIBAT" }, 
+                    { "low": 41, "high": 44, "species": "SPECIES_KROOKODILE" }
+                ]
+            },
+            "rocks": {
+                "rate": 50,
+                "pokemon": [
+                    { "low": 37, "high": 42, "species": "SPECIES_GIGALITH" },
+                    { "low": 38, "high": 43, "species": "SPECIES_COALOSSAL" },
+                    { "low": 38, "high": 43, "species": "SPECIES_SHUCKLE" },
+                    { "low": 37, "high": 44, "species": "SPECIES_COALOSSAL" },
+                    { "low": 36, "high": 42, "species": "SPECIES_GIGALITH" }
+                ]
+            }
+        },
+        {
             "mapgroup": 3,
             "mapnum": 2,
             "surfing": {

--- a/eventscripts
+++ b/eventscripts
@@ -241,3 +241,9 @@ npc 1 1 16 EventScript_RubarrDesert_TMFlameCharge
 npc 1 1 17 ItemScript_Common_Greatball
 npc 1 1 18 ItemScript_Common_SoftSand
 npc 1 1 19 ItemScript_Common_StarPiece
+npc 1 1 20 EventScript_Common_Strength
+npc 1 1 21 EventScript_Common_Strength
+npc 1 1 22 EventScript_Common_Strength
+npc 1 1 23 EventScript_Common_Strength
+npc 1 1 24 ItemScript_Common_FocusSash
+sign 1 1 0 SignScript_RubarrDesert_Oasis

--- a/eventscripts
+++ b/eventscripts
@@ -246,4 +246,27 @@ npc 1 1 21 EventScript_Common_Strength
 npc 1 1 22 EventScript_Common_Strength
 npc 1 1 23 EventScript_Common_Strength
 npc 1 1 24 ItemScript_Common_FocusSash
+npc 1 1 25 EventScript_RubarrDesert_CaveGuide
 sign 1 1 0 SignScript_RubarrDesert_Oasis
+
+## Cave BF1
+npc 1 2 0 EventScript_Common_RockSmash
+npc 1 2 1 EventScript_Common_RockSmash
+npc 1 2 2 EventScript_Common_RockSmash
+npc 1 2 3 EventScript_Common_RockSmash
+npc 1 2 4 EventScript_Common_Strength
+npc 1 2 5 EventScript_Common_Strength
+
+## Cave BF2
+npc 1 3 0 EventScript_Common_Strength
+npc 1 3 1 EventScript_Common_Strength
+npc 1 3 2 EventScript_Common_Strength
+npc 1 3 3 EventScript_Common_Strength
+npc 1 3 4 EventScript_Common_Strength
+npc 1 3 5 EventScript_Common_Strength
+npc 1 3 6 EventScript_Common_RockSmash
+npc 1 3 7 EventScript_Common_RockSmash
+npc 1 3 8 EventScript_Common_RockSmash
+npc 1 3 9 EventScript_Common_RockSmash
+npc 1 3 10 EventScript_Common_RockSmash
+npc 1 3 11 EventScript_Common_RockSmash

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -374,7 +374,7 @@
 #define FLAG_HIDE_RUBARR_DESERT_GREAT_BALL                      0x16C
 #define FLAG_HIDE_RUBARR_DESERT_SOFT_SAND                       0x16D
 #define FLAG_HIDE_RUBARR_DESERT_STAR_PIECE                      0x16E
-#define FLAG_HIDE_ROCKET_HIDEOUT_B2F_MOON_STONE                 0x16F
+#define FLAG_HIDE_RUBARR_DESERT_FOCUS_SASH                      0x16F
 #define FLAG_HIDE_ROCKET_HIDEOUT_B2F_TM12                       0x170
 #define FLAG_HIDE_ROCKET_HIDEOUT_B2F_SUPER_POTION               0x171
 #define FLAG_HIDE_ROCKET_HIDEOUT_B3F_RARE_CANDY                 0x172

--- a/strings/scripts/dungeons/rubarr_desert.string
+++ b/strings/scripts/dungeons/rubarr_desert.string
@@ -46,5 +46,14 @@ Well that wasn't very kind of you.
 #org @gText_RubarrDesert_RuinManiacAlbert_Chat
 There are so many discoveries to be\nmade in Rubarr Desert.
 
+#org @gText_RubarrDesert_TourGuideIntro
+Hey! I'm a tour guide for Rubarr\nDesert. Would you like to know\lmore about the area?
+
+#org @gText_RubarrDesert_TourGuideDetails
+Rubarr Desert is an intense desert\nwhere the weather changes\lunpredictably.\pYou'll experience sandstorms that\nwill chip away at your Pok\emon's\lhealth, or intense sun that\lstrengthens fire type moves and\lweakens water type ones.\pTake caution if you choose to\nexplore the deserts' caves. Very\lpowerful Pok\emon dwell there.\pI hope this information has been\nhelpful to you.
+
+#org @gText_RubarrDesert_TourGuideFarewell
+Take care out there, trainer!
+
 #org @gText_RubarrDesert_OasisSign
 Rubarr Desert Oasis\nPlease keep our water clean!

--- a/strings/scripts/dungeons/rubarr_desert.string
+++ b/strings/scripts/dungeons/rubarr_desert.string
@@ -45,3 +45,6 @@ Well that wasn't very kind of you.
 
 #org @gText_RubarrDesert_RuinManiacAlbert_Chat
 There are so many discoveries to be\nmade in Rubarr Desert.
+
+#org @gText_RubarrDesert_OasisSign
+Rubarr Desert Oasis\nPlease keep our water clean!


### PR DESCRIPTION
Update events for Rubarr Desert

- Improve cut/rock smash/strength scripts
- Add a missing script end statement
- Add a tour guide to Rubarr overworld to warn players not to go into the caves
- Add wild encounters to Rubarr caves so they aren't totally empty, but no items yet
- Add an extra item to the desert