### PR TITLE
Add daily events for OW wild pokemon

### DIFF
--- a/assembly/overworld_scripts/dungeons/torma_cave.s
+++ b/assembly/overworld_scripts/dungeons/torma_cave.s
@@ -10,12 +10,52 @@
 .global MapScript_TormaCave
 MapScript_TormaCave:
     mapscript MAP_SCRIPT_ON_TRANSITION MapEntryScript_TormaCave_FlightFlag
+    mapscript MAP_SCRIPT_ON_LOAD SetStunfiskTrapsVisbility
 	.byte MAP_SCRIPT_TERMIN
 
 MapEntryScript_TormaCave_FlightFlag:
     setworldmapflag 0x8A6
     setvar FormanEventVar 0x0
     end
+
+SetStunfiskTrapsVisbility:
+    checkflag 0xE03
+    if NOT_SET _call SetStunfisk1Visibility
+    if SET _call HideStunfisk1
+    checkflag 0xE04
+    if NOT_SET _call SetStunfisk2Visibility
+    if SET _call HideStunfisk2
+    checkflag 0xE05
+    if NOT_SET _call SetStunfisk3Visibility
+    if SET _call HideStunfisk3
+    end
+
+SetStunfisk1Visibility:
+    setmaptile 0x10 0x20 0x30B 0x0
+    return
+
+HideStunfisk1:
+    setmaptile 0x10 0x20 0x281 0x0
+    special 0x8E
+    return
+
+HideStunfisk2:
+    setmaptile 0x2F 0x11 0x281 0x0
+    special 0x8E
+    return
+
+HideStunfisk3:
+    setmaptile 0x1C 0xA 0x281 0x0
+    special 0x8E
+    return
+
+SetStunfisk2Visibility:
+    setmaptile 0x2F 0x11 0x30B 0x0
+    return
+
+SetStunfisk3Visibility:
+    setmaptile 0x1C 0xA 0x30B 0x0
+    return
 
 .global EventScript_TormaCave_RockyHelmet
 EventScript_TormaCave_RockyHelmet:
@@ -74,16 +114,54 @@ SignScript_TormaCave_TrainerTips:
     msgbox gText_TormaCave_TrainerTips MSG_SIGN
     end
 
-.global EventScript_TormaCave_SetPathCleared
-EventScript_TormaCave_SetPathCleared:
+.global TileScript_TormaCave_StunfiskEncounter1
+TileScript_TormaCave_StunfiskEncounter1:
+    checkflag 0xE03
+    if SET _goto End
+    call StunfiskEncounter
+    setflag 0xE03
+    call HideStunfisk1
+    end
+
+.global TileScript_TormaCave_StunfiskEncounter2
+TileScript_TormaCave_StunfiskEncounter2:
+    checkflag 0xE04
+    if SET _goto End
+    call StunfiskEncounter
+    setflag 0xE04
+    call HideStunfisk2
+    end
+
+.global TileScript_TormaCave_StunfiskEncounter3
+TileScript_TormaCave_StunfiskEncounter3:
+    checkflag 0xE05
+    if SET _goto End
+    call StunfiskEncounter
+    setflag 0xE05
+    call HideStunfisk3
+    end
+
+StunfiskEncounter:
+    lock
+    checksound
+    cry SPECIES_STUNFISK_G 0x0
+    applymovement PLAYER m_Surprise
+    msgbox gText_TormaCave_StunfiskEncounter MSG_KEEPOPEN
+    wildbattle SPECIES_STUNFISK_G 0xE 0x0
+    hidesprite LASTTALKED
+    release
+    return
+
+.global TileScript_TormaCave_SetPathCleared
+TileScript_TormaCave_SetPathCleared:
     setflag 0x35 @ Cleared Torma Cave
     @ Set the other tile event up to execute
     setvar 0x4000 0x1
     setvar 0x4001 0x0
     end
 
-.global EventScript_TormaCave_ClearPathCleared
-EventScript_TormaCave_ClearPathCleared:
+.global TileScript_TormaCave_ClearPathCleared
+TileScript_TormaCave_ClearPathCleared:
     # Only clear the flag indicating that Torma Cave has been cleared if the player hasn't spoken with the Foreman upon leaving
     # This avoids a case where the player goes to the end of the cave, leaves from the start, and breaks the cutscene
     checkflag 0x36 @ Met with Foreman

--- a/assembly/overworld_scripts/dungeons/varisi_forest.s
+++ b/assembly/overworld_scripts/dungeons/varisi_forest.s
@@ -82,13 +82,13 @@ EventScript_VarisiForest_FriendlyTrainer:
 .global EventScript_VarisiForest_FoongusEncounter1
 EventScript_VarisiForest_FoongusEncounter1:
     call FoongusEncounter
-    setflag 0x055
+    setflag 0xE01
     end
 
 .global EventScript_VarisiForest_FoongusEncounter2
 EventScript_VarisiForest_FoongusEncounter2:
     call FoongusEncounter
-    setflag 0x056
+    setflag 0xE02
     end
 
 FoongusEncounter:

--- a/assembly/overworld_scripts/routes/route_1.s
+++ b/assembly/overworld_scripts/routes/route_1.s
@@ -37,7 +37,7 @@ EventScript_Route1_SandygastEncounter:
     msgbox gText_Route1_SandygastEncounter MSG_KEEPOPEN
     wildbattle SPECIES_SANDYGAST 0x5 0x0
     hidesprite LASTTALKED
-    setflag 0x054
+    setflag 0xE00
     release
     end
 

--- a/eventscripts
+++ b/eventscripts
@@ -339,8 +339,11 @@ npc 1 4 15 EventScript_Common_RockSmash
 npc 1 4 16 EventScript_Common_RockSmash
 npc 1 4 17 EventScript_Common_RockSmash
 npc 1 4 18 EventScript_Common_RockSmash
-tile 1 4 0 EventScript_TormaCave_SetPathCleared
-tile 1 4 1 EventScript_TormaCave_ClearPathCleared
+tile 1 4 0 TileScript_TormaCave_SetPathCleared
+tile 1 4 1 TileScript_TormaCave_ClearPathCleared
+tile 1 4 2 TileScript_TormaCave_StunfiskEncounter1
+tile 1 4 3 TileScript_TormaCave_StunfiskEncounter2
+tile 1 4 4 TileScript_TormaCave_StunfiskEncounter3
 
 ## BF2
 npc 1 5 0 EventScript_Common_Strength

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -87,9 +87,9 @@
 #define FLAG_HIDE_TOWER_RIVAL                              0x051
 #define FLAG_HIDE_MOLTRES                                  0x052
 #define FLAG_HIDE_SILPH_ROCKETS                            0x053
-#define FLAG_HIDE_ROUTE_1_SANDYGAST                        0x054
-#define FLAG_HIDE_VARISI_FOONGUS_1                         0x055
-#define FLAG_HIDE_VARISI_FOONGUS_2                         0x056
+#define FLAG_HIDE_ROUTE_12_SNORLAX                         0x054
+#define FLAG_HIDE_VIRIDIAN_GIOVANNI                        0x055
+#define FLAG_HIDE_OLD_AMBER                                0x056
 #define FLAG_HIDE_EEVEE_BALL                               0x057
 #define FLAG_HIDE_VICTORY_ROAD_2F_BOULDER                  0x058
 #define FLAG_HIDE_VICTORY_ROAD_3F_BOULDER                  0x059
@@ -1312,6 +1312,16 @@
 #define FLAG_0x4FD               0x4FD
 #define FLAG_0x4FE               0x4FE
 #define FLAG_0x4FF               0x4FF
+*/
+
+/*
+Daily Flags, cleared at the start of each day.  Goes up to 0xEFF
+#define FLAG_ROUTE_1_SANDYGAST                0xE00
+#define FLAG_VARISI_FOREST_FOONGUS_1          0xE01
+#define FLAG_VARISI_FOREST_FOONGUS_2          0xE02
+#define FLAG_TORMA_CAVE_STUNFISK_G_1          0xE03
+#define FLAG_TORMA_CAVE_STUNFISK_G_2          0xE04
+#define FLAG_TORMA_CAVE_STUNFISK_G_3          0xE05
 */
 
 #define FLAG_TRAINER_FLAG_START 0x500

--- a/strings/scripts/dungeons/torma_cave.string
+++ b/strings/scripts/dungeons/torma_cave.string
@@ -63,3 +63,6 @@ I should've done some research\nbefore coming down here[.] It's\lfreezing!
 
 #org @gText_TormaCave_TrainerTips
 Trainer Tips!\nStepping onto a sheet of ice will\lcause you to slide until you\lcollide with something.\lTake care when stepping onto ice!
+
+#org @gText_TormaCave_StunfiskEncounter
+There was a wild Pok\emon hiding at\nyour feet! The Pok\emon attacked!


### PR DESCRIPTION
Modify overworld pokemon events to be daily events.  Stunfisk events in Torma Cave will trigger when the player steps on them.