### PR TITLE
Typo fix and custom egg code

### DIFF
--- a/assembly/overworld_scripts/ferrox_village/ferrox_gym.s
+++ b/assembly/overworld_scripts/ferrox_village/ferrox_gym.s
@@ -145,14 +145,14 @@ EventScript_FerroxLibrary_ReadBookPromptY:
     msgbox gText_FerroxLibrary_ReadBookPrompt_Y MSG_SIGN
     end
 
-.global EventScript_FerroxLibrary_Receiptionist1
-EventScript_FerroxLibrary_Receiptionist1:
-    npcchat gText_FerroxLibrary_Receiptionist1
+.global EventScript_FerroxLibrary_Receptionist1
+EventScript_FerroxLibrary_Receptionist1:
+    npcchat gText_FerroxLibrary_Receptionist1
     end
 
-.global EventScript_FerroxLibrary_Receiptionist2
-EventScript_FerroxLibrary_Receiptionist2:
-    npcchat gText_FerroxLibrary_Receiptionist2
+.global EventScript_FerroxLibrary_Receptionist2
+EventScript_FerroxLibrary_Receptionist2:
+    npcchat gText_FerroxLibrary_Receptionist2
     end
 
 .global EventScript_FerroxLibrary_PCUser

--- a/eventscripts
+++ b/eventscripts
@@ -447,8 +447,8 @@ npc 7 5 1 EventScript_FerroxGym_LeaderStella
 
 ## Library
 map 7 9 MapScript_FerroxLibrary
-npc 7 9 0 EventScript_FerroxLibrary_Receiptionist1
-npc 7 9 1 EventScript_FerroxLibrary_Receiptionist2
+npc 7 9 0 EventScript_FerroxLibrary_Receptionist1
+npc 7 9 1 EventScript_FerroxLibrary_Receptionist2
 npc 7 9 2 EventScript_FerroxLibrary_PCUser
 npc 7 9 3 EventScript_FerroxLibrary_TableReader1
 npc 7 9 4 EventScript_FerroxLibrary_TableReader2

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -1048,3 +1048,78 @@ bool8 ShouldSkipOfferEggHatchNickname(void)
 	return FALSE;
 	#endif
 }
+
+void GiveCustomEgg()
+{
+    u16 species = Var8005;
+    u16 customEggIndex = Var8006;
+    struct Pokemon *mon = AllocZeroed(sizeof(struct Pokemon));
+    bool8 isEgg;
+    bool8 sentToPc;
+
+    CreateEgg(mon, species);
+    isEgg = TRUE;
+    SetMonData(mon, MON_DATA_IS_EGG, &isEgg);
+    switch(customEggIndex)
+    {
+		// Note: Starter vars are 0 based (ex. 0x408C for grass)
+        case 0: // Starter Event Gen 1 (Pichu)
+            SetMonMoveSlot(mon, MOVE_THUNDERSHOCK, 0);
+            SetMonMoveSlot(mon, MOVE_CHARM, 1);
+            SetMonMoveSlot(mon, MOVE_FAKEOUT, 2);
+            SetMonMoveSlot(mon, MOVE_NONE, 3);
+            break;
+
+		case 1: // Starter Event Gen 2 (Togepi)
+            SetMonMoveSlot(mon, MOVE_GROWL, 0);
+            SetMonMoveSlot(mon, MOVE_CHARM, 1);
+            SetMonMoveSlot(mon, MOVE_MORNINGSUN, 2);
+            SetMonMoveSlot(mon, MOVE_NONE, 3);
+            break;
+
+		case 2: // Starter Event Gen 3 (Wynaut)
+            SetMonMoveSlot(mon, MOVE_SPLASH, 0);
+            SetMonMoveSlot(mon, MOVE_CHARM, 1);
+            SetMonMoveSlot(mon, MOVE_ENCORE, 2);
+            SetMonMoveSlot(mon, MOVE_NONE, 3);
+            break;
+
+		case 3: // Starter Event Gen 4 (Riolu)
+            SetMonMoveSlot(mon, MOVE_FORESIGHT, 0);
+            SetMonMoveSlot(mon, MOVE_QUICKATTACK, 1);
+            SetMonMoveSlot(mon, MOVE_ENDURE, 2);
+            SetMonMoveSlot(mon, MOVE_BULLETPUNCH, 3);
+            break;
+
+		case 4: // Starter Event Gen 5 (Larvesta)
+            SetMonMoveSlot(mon, MOVE_EMBER, 0);
+            SetMonMoveSlot(mon, MOVE_STRINGSHOT, 1);
+            SetMonMoveSlot(mon, MOVE_MORNINGSUN, 2);
+            SetMonMoveSlot(mon, MOVE_NONE, 3);
+            break;
+
+		case 5: // Starter Event Gen 6 (Happiny)
+            SetMonMoveSlot(mon, MOVE_POUND, 0);
+            SetMonMoveSlot(mon, MOVE_CHARM, 1);
+            SetMonMoveSlot(mon, MOVE_METRONOME, 2);
+            SetMonMoveSlot(mon, MOVE_NONE, 3);
+            break;
+
+		case 6: // Starter Event Gen 7 (Eevee)
+            SetMonMoveSlot(mon, MOVE_HELPINGHAND, 0);
+            SetMonMoveSlot(mon, MOVE_GROWL, 1);
+            SetMonMoveSlot(mon, MOVE_TACKLE, 2);
+            SetMonMoveSlot(mon, MOVE_YAWN, 3);
+            break;
+
+		case 7: // Starter Event Gen 8 (Toxel)
+            SetMonMoveSlot(mon, MOVE_ACID, 0);
+            SetMonMoveSlot(mon, MOVE_TEARFULLOOK, 1);
+            SetMonMoveSlot(mon, MOVE_NUZZLE, 2);
+            SetMonMoveSlot(mon, MOVE_POWERUPPUNCH, 3);
+            break;
+    }
+
+    sentToPc = GiveMonToPlayer(mon);
+    Free(mon);
+}

--- a/strings/scripts/ferrox_village/ferrox_gym.string
+++ b/strings/scripts/ferrox_village/ferrox_gym.string
@@ -67,10 +67,10 @@ Researches have yet to find\nconclusive p[GREEN]r[BLACK]oof, but have reason\lto
 #org @gText_FerroxLibrary_ReadBookPrompt_Y
 Due to interdimensional research\ngripping the region's interests, the\lm[GREEN]y[BLACK]stery of whether mythical\lPok\emon within the region actually\lexist has diminished significantly.
 
-#org @gText_FerroxLibrary_Receiptionist1
+#org @gText_FerroxLibrary_Receptionist1
 Welcome to the Ferrox Village\nlibrary!\lYou're free to read any books in\lthe library, free of charge.\pSome visitors may seek a battle with\nyou. If you choose to do so,\lplease battle quietly to be\lrespectful to our other guests.
 
-#org @gText_FerroxLibrary_Receiptionist2
+#org @gText_FerroxLibrary_Receptionist2
 Do you have any books to return?\nNo? Very well.
 
 #org @gText_FerroxLibrary_PCUser


### PR DESCRIPTION
Adds custom code by Greenphx for creating customized eggs.

Each egg is 0-indexed and aligns with the player's grass starter selection.  Eg. Bulbsauar is 0, Chikorita is 1, etc.
This will be used to determine which egg the player gets.
Each egg aligns with an egg received in that gen, and comes with an egg move.