### PR TITLE
Poke chip dialog

### DIFF
--- a/assembly/overworld_scripts/ferrox_village/ferrox_npc_houses.s
+++ b/assembly/overworld_scripts/ferrox_village/ferrox_npc_houses.s
@@ -32,6 +32,8 @@ BerryGirlEnd:
 EventScript_FerroxNPCHouses_MoveTutor:
     lock
     faceplayer
+    callasm StorePokeChipCount
+	buffernumber 0x0 0x8005 @ Take stored PokeChip count
     msgbox gText_FerroxNPCHouses_TutorConfirmation MSG_YESNO
     compare LASTRESULT YES
     IF FALSE _goto TutoringRejected

--- a/assembly/overworld_scripts/heleo_city/heleo_city_npc_houses.s
+++ b/assembly/overworld_scripts/heleo_city/heleo_city_npc_houses.s
@@ -30,6 +30,8 @@ EventScript_HeleoCity_ForemanAssistant:
 EventScript_HeleoCity_MoveTutor:
     lock
     faceplayer
+    callasm StorePokeChipCount
+	buffernumber 0x0 0x8005 @ Take stored PokeChip count
     msgbox gText_HeleoNPCHouses_TutorConfirmation MSG_YESNO
     compare LASTRESULT YES
     IF FALSE _goto TutoringRejected

--- a/assembly/overworld_scripts/heleo_city/heleo_city_overworld.s
+++ b/assembly/overworld_scripts/heleo_city/heleo_city_overworld.s
@@ -56,6 +56,8 @@ JumpingKidDone:
 EventScript_HeleoCity_ShadyDealer:
     lock
     faceplayer
+    callasm StorePokeChipCount
+	buffernumber 0x0 0x8005 @ Take stored PokeChip count
     msgbox gText_HeleoCityOverworld_ShadyDealerProposition MSG_YESNO
     compare LASTRESULT NO
     if equal _goto ShadyDealerRejected

--- a/assembly/overworld_scripts/rhodanzi_city/rhodanzi_trainer_school.s
+++ b/assembly/overworld_scripts/rhodanzi_city/rhodanzi_trainer_school.s
@@ -61,6 +61,8 @@ EventScript_RhodanziTrainerSchool_TerrainTutor:
     end
 
 TerrainTutor:
+    callasm StorePokeChipCount
+	buffernumber 0x0 0x8005 @ Take stored PokeChip count
     msgbox gText_RhodanziTrainerSchool_MainRoom_TerrainTutor_Confirmation MSG_YESNO
     compare LASTRESULT YES
     IF FALSE _goto TutoringRejected

--- a/src/item.c
+++ b/src/item.c
@@ -2185,3 +2185,8 @@ u16 GetBestBallInBag(void)
 
 	return bestBall;
 }
+
+void StorePokeChipCount(void)
+{
+	VarSet(0x8005, CountTotalItemQuantityInBag(ITEM_POKE_CHIP));
+}

--- a/strings/scripts/ferrox_village/ferrox_npc_houses.string
+++ b/strings/scripts/ferrox_village/ferrox_npc_houses.string
@@ -8,7 +8,7 @@ I tend to the village's berry\ngardens.\pHere, you can have a free sample!
 Come back tomorrow for another\nberry!
 
 #org @gText_FerroxNPCHouses_TutorConfirmation
-I'm well versed in tutoring Pok\emon.\nI can teach your Pok\emon some new\lmoves, in exchange for 5 Pok\eChips.
+Hello! I'm an experienced move\ntutor. I can teach your Pok\emon\lnew and exciting moves.\pMy fee is 5 Pok\eChips. What do you\nsay? (Held: [BUFFER1])
 
 #org @gText_FerroxNPCHouses_ConfirmationAccepted
 Great! Let's get started.

--- a/strings/scripts/heleo_city/heleo_city_npc_houses.string
+++ b/strings/scripts/heleo_city/heleo_city_npc_houses.string
@@ -11,7 +11,7 @@ The foreman seems like a scary guy,\nbut he actually has a heart of\lgold.
 My daddy taught my Pok\emon a lot of\nreally cool moves! He's so smart!
 
 #org @gText_HeleoNPCHouses_TutorConfirmation
-Hello! I'm an experienced move\ntutor.\pI can teach your Pok\emon new and\nexciting moves, in exchange for 5\lPok\eChips! What do you say?
+Hello! I'm an experienced move\ntutor. I can teach your Pok\emon\lnew moves.\pMy fee is 5 Pok\eChips. What\ndo you say? (Held: [BUFFER1])
 
 #org @gText_HeleoNPCHouses_ConfirmationAccepted
 Great! These are the moves I can\nteach. Which interests you?

--- a/strings/scripts/heleo_city/heleo_city_overworld.string
+++ b/strings/scripts/heleo_city/heleo_city_overworld.string
@@ -20,7 +20,7 @@ I have a gift for you[.] Doesn't it\nmake you feel like you're walking\lon air?
 Well, I'd better get back to jumping.\nYou should too!
 
 #org @gText_HeleoCityOverworld_ShadyDealerProposition
-Psst! You - yeah, you!\pI got ahold of something rare,\nstranger, but I need to get rid of\lit before the fuzz catch up to me.\pYou look like a smart kid[.] It can be\nyours, for 1 Pok\eChip.
+Psst! You - yeah, you!\pI got ahold of something rare,\nstranger, but I need to get rid of\lit before the fuzz catch up to me.\pYou look like a smart kid[.]\pThis item can be yours, for 1\nPok\eChip. (Held: [BUFFER1])
 
 #org @gText_HeleoCityOverworld_ShadyDealerDeclined
 Heh heh, tryin' to keep your nose\nclean, eh?\pThat's fine with me. Someone else'll\nbe interested in what I've got.

--- a/strings/scripts/rhodanzi_city/rhodanzi_trainer_school.string
+++ b/strings/scripts/rhodanzi_city/rhodanzi_trainer_school.string
@@ -29,7 +29,7 @@ In my time, I have become a\nproficient Pok\emon move tutor. I\lcan teach your P
 Unfortunately, I cannot teach you\nuntil you have acquired the Terrain\lBadge from the Rhodanzi City Gym.\pPlease come back once you have it,\nand I'll be happy to teach your\lPok\emon!
 
 #org @gText_RhodanziTrainerSchool_MainRoom_TerrainTutor_Confirmation
-To teach your Pok\emon, I will\nrequire 5 Pok\eChips. Is this\lacceptable?
+To teach your Pok\emon, I will\nrequire 5 Pok\eChips as payment. Is\lthis acceptable? (Held: [BUFFER1])
 
 #org @gText_RhodanziTrainerSchool_MainRoom_TerrainTutor_NotEnoughPokeChips
 I'm sorry, but you don't have enough\nPok\eChips to cover my fee.


### PR DESCRIPTION
Adds the number of pokechips the player currently holds to all interactions that require a pokechip.

Low-tech solution; more impressive ones I found had issues injecting, and this is meant more for QOL than anything.

![image](https://github.com/assassinsgreed/Complete-Fire-Red-Upgrade/assets/2691249/73ed796d-eecf-4d12-af0a-c46c60e95443)
