### PR TITLE
Fix TM sorting by just sorting against TMHM ids

### DIFF
--- a/assembly/overworld_scripts/common/items.s
+++ b/assembly/overworld_scripts/common/items.s
@@ -117,6 +117,11 @@ ItemScript_Common_AbsorbBulb:
     finditem ITEM_ABSORB_BULB 0x1
     end
 
+.global ItemScript_Common_CellBattery
+ItemScript_Common_CellBattery:
+    finditem ITEM_CELL_BATTERY 0x1
+    end
+
 .global ItemScript_Common_MiracleSeed
 ItemScript_Common_MiracleSeed:
     finditem ITEM_MIRACLE_SEED 0x1

--- a/assembly/overworld_scripts/dungeons/heleo_ranch.s
+++ b/assembly/overworld_scripts/dungeons/heleo_ranch.s
@@ -7,8 +7,13 @@
 
 .global MapScript_HeleoRanchExterior
 MapScript_HeleoRanchExterior:
+    mapscript MAP_SCRIPT_ON_TRANSITION MapEntryScript_HeleoRanch_FlightFlag
     mapscript MAP_SCRIPT_ON_LOAD MapEntryScript_HeleoRanch_HandleMareepVisibility
 	.byte MAP_SCRIPT_TERMIN
+
+MapEntryScript_HeleoRanch_FlightFlag:
+    setworldmapflag 0x8A7 @ Been to Heleo Ranch
+    end
 
 MapEntryScript_HeleoRanch_HandleMareepVisibility:
     @ Check time of day

--- a/assembly/overworld_scripts/dungeons/rubarr_desert.s
+++ b/assembly/overworld_scripts/dungeons/rubarr_desert.s
@@ -19,7 +19,7 @@ MapScript_RubarrDesert:
 	.byte MAP_SCRIPT_TERMIN
 
 MapEntryScript_RubarrDesert_FlightFlag:
-    setworldmapflag 0x8A5
+    setworldmapflag 0x8A5 @ Been to Rubarr Desert
     setflag 0x34 @ Hide Rival and Irene
     end
 

--- a/assembly/overworld_scripts/dungeons/torma_cave.s
+++ b/assembly/overworld_scripts/dungeons/torma_cave.s
@@ -14,7 +14,7 @@ MapScript_TormaCave:
 	.byte MAP_SCRIPT_TERMIN
 
 MapEntryScript_TormaCave_FlightFlag:
-    setworldmapflag 0x8A6
+    setworldmapflag 0x8A6 @ Been to Torma Cave
     setvar FormanEventVar 0x0
     end
 

--- a/assembly/overworld_scripts/heleo_city/heleo_city_npc_houses.s
+++ b/assembly/overworld_scripts/heleo_city/heleo_city_npc_houses.s
@@ -404,17 +404,17 @@ EventScript_HeleoCity_HallwayBoy:
 
 .global EventScript_HeleoCity_TerraceDad
 EventScript_HeleoCity_TerraceDad:
-    npcchat2 0x0 m_LookLeft gText_HeleoNPCHouses_TerraceDad
+    npcchat2 0x1 m_LookLeft gText_HeleoNPCHouses_TerraceDad
     end
 
 .global EventScript_HeleoCity_TerraceMom
 EventScript_HeleoCity_TerraceMom:
-    npcchat2 0x1 m_LookLeft gText_HeleoNPCHouses_TerraceMom
+    npcchat2 0x2 m_LookLeft gText_HeleoNPCHouses_TerraceMom
     end
 
 .global EventScript_HeleoCity_TerraceSon
 EventScript_HeleoCity_TerraceSon:
-    npcchat2 0x2 m_LookRight gText_HeleoNPCHouses_TerraceSon
+    npcchat2 0x3 m_LookRight gText_HeleoNPCHouses_TerraceSon
     end
 
 .global EventScript_HeleoCity_SodaMachineGirl

--- a/eventscripts
+++ b/eventscripts
@@ -595,6 +595,7 @@ npc 3 4 3 EventScript_HeleoCity_FountainKid
 npc 3 4 4 EventScript_HeleoCity_BigGuy
 npc 3 4 5 EventScript_HeleoCity_TrainerHouseGirl
 npc 3 4 6 EventScript_HeleoCity_RaineFan
+npc 3 4 7 ItemScript_Common_CellBattery
 sign 3 4 0 SignScript_HeleoCity_CitySign
 sign 3 4 1 SignScript_HeleoCity_GymSign
 sign 3 4 2 SignScript_HeleoCity_TrainerHouseSign

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -425,7 +425,7 @@
 #define FLAG_HIDE_ROUTE_6_IRON                                  0x19F
 #define FLAG_HIDE_ROUTE_6_RARE_CANDY                            0x1A0
 #define FLAG_HIDE_ROUTE_6_NUGGET                                0x1A1
-#define FLAG_HIDE_POKEMON_MANSION_3F_MAX_POTION                 0x1A2
+#define FLAG_HIDE_HELEO_CITY_CELL_BATTERY                       0x1A2
 #define FLAG_HIDE_POKEMON_MANSION_3F_IRON                       0x1A3
 #define FLAG_HIDE_POKEMON_MANSION_B1F_TM14                      0x1A4
 #define FLAG_HIDE_POKEMON_MANSION_B1F_FULL_RESTORE              0x1A5
@@ -1060,7 +1060,7 @@
 #define HIDDEN_ITEM_ROUTE6_STAR_PIECE                                  31
 #define HIDDEN_ITEM_ROUTE6_HP_UP                                       32
 #define HIDDEN_ITEM_ROUTE6_ELIXIR                                      33
-#define HIDDEN_ITEM_ROUTE23_FULL_RESTORE                               34
+#define HIDDEN_ITEM_HELEO_CITY_FRESH_WATER                             34
 #define HIDDEN_ITEM_ROUTE23_ULTRA_BALL                                 35
 #define HIDDEN_ITEM_ROUTE23_MAX_ETHER                                  36
 #define HIDDEN_ITEM_VICTORY_ROAD_1F_ULTRA_BALL                         37

--- a/include/constants/region_map_sections.h
+++ b/include/constants/region_map_sections.h
@@ -46,7 +46,7 @@ u8 __attribute__((long_call)) GetCurrentRegionMapSectionId(void);
 #define MAPSEC_VIRIDIAN_FOREST              0x7E
 #define MAPSEC_MT_MOON                      0x7F
 #define MAPSEC_TORMA_CAVE                   0x80
-#define MAPSEC_UNDERGROUND_PATH             0x81
+#define MAPSEC_HELEO_RANCH                  0x81
 #define MAPSEC_FORGOTTEN_MANSE              0x82
 #define MAPSEC_DIGLETTS_CAVE                0x83
 #define MAPSEC_VICTORY_ROAD                 0x84

--- a/src/item.c
+++ b/src/item.c
@@ -1665,12 +1665,12 @@ static s8 CompareTMs(struct ItemSlot* itemSlot1, struct ItemSlot* itemSlot2)
 	else if (id2 <= NUM_TMS && id1 > NUM_TMS)
 		return 1;
 	#else
-	if (id2 <= NUM_TMS && id1 > NUM_TMS)
-		return -1;
-	else if (id1 <= NUM_TMS && id2 > NUM_TMS)
-		return 1;
+	// if (id2 <= NUM_TMS && id1 > NUM_TMS)
+	// 	return -1;
+	// else if (id1 <= NUM_TMS && id2 > NUM_TMS)
+	// 	return 1;
 	#endif
-	else if (id1 < id2)
+	if (id1 < id2)
 		return -1;
 	else if (id2 > id1)
 		return 1;

--- a/strings/scripts/heleo_city/heleo_city_overworld.string
+++ b/strings/scripts/heleo_city/heleo_city_overworld.string
@@ -32,7 +32,7 @@ Oy, what gives? You don't even have\na single Pok\eChip?\pScram! This isn't a ch
 Heheheh, wise move, kiddo.\pI gotta scram. I'll be back with\nmore procured goods tomorrow,\lcapiche?
 
 #org @gText_HeleoCityOverworld_Route8Girl
-A lot of trainers choose to follow\nRoute 8 to Daimyn City.\pIt's longer than Route 6, but doesn't\nattract serious trainers like Route\l6 does.
+A lot of new trainers have trouble\nwith Route 8.\pIt's very long and is covered with\ndifficult terrain. Furthermore, it\lrains frequently[.]\pBut, there are interesting points of\ninterest there that can make the\ltrek worth it.
 
 #org @gText_HeleoCityOverworld_FountainKid
 Wow! I can see coins at the bottom\nof this fountain.\pIf I can just find a way to reach\nthem, I'll be rich[.]


### PR DESCRIPTION
Fix TM HM sorting.  Previously, the sort would compare against the number of TMs and HMs defined.  This check is unnecessary (and appears to not play nicely with our data) if all TMs and HMs have an internal ID.  Instead, those internal IDs can be used to handle sorting.