### PR TITLE
Daimyn City overworld events and fix for restaurant meal buff

### DIFF
--- a/assembly/overworld_scripts/daimyn_city/ascension_tower.s
+++ b/assembly/overworld_scripts/daimyn_city/ascension_tower.s
@@ -1,0 +1,91 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+.include "../asm_defines.s"
+
+.global MapScript_AscensionTower
+MapScript_AscensionTower:
+    mapscript MAP_SCRIPT_ON_TRANSITION MapEntryScript_AscensionTower_FlightFlag
+    .byte MAP_SCRIPT_TERMIN
+
+MapEntryScript_AscensionTower_FlightFlag:
+    setworldmapflag 0x8B2 @ Been to Ascension Tower
+    end
+
+.global EventScript_AscensionTower_BattleTowerAttendant
+EventScript_AscensionTower_BattleTowerAttendant:
+    lock
+    msgbox gText_AscensionTower_BattleTowerAttendant_Introduction MSG_KEEPOPEN
+    multichoiceoption gText_Yes 0
+	multichoiceoption gText_Info 1
+	multichoiceoption gText_No 2
+    multichoice 0x60 0x0 THREE_MULTICHOICE_OPTIONS FALSE
+	copyvar MULTICHOICE_SELECTION LASTRESULT
+	switch LASTRESULT
+	case 0, TakeBattleTowerChallenge
+	case 1, BattleTowerInfo
+	case 2, AttendantChoseNo
+    goto AttendantChoseNo
+
+TakeBattleTowerChallenge:
+    @ Later, perform a check here for the champions flag
+    msgbox gText_AscensionTower_BattleTowerAttendant_NotChampion MSG_NORMAL
+    release
+    end
+
+BattleTowerInfo:
+    msgbox gText_AscensionTower_EliteFourAttendant_BattleTowerInfo MSG_NORMAL
+    goto EventScript_AscensionTower_BattleTowerAttendant
+
+.global EventScript_AscensionTower_EliteFourAttendant
+EventScript_AscensionTower_EliteFourAttendant:
+    lock
+    msgbox gText_AscensionTower_EliteFourAttendant_Introduction MSG_KEEPOPEN
+    multichoiceoption gText_Yes 0
+	multichoiceoption gText_Info 1
+	multichoiceoption gText_No 2
+    multichoice 0x60 0x0 THREE_MULTICHOICE_OPTIONS FALSE
+	copyvar MULTICHOICE_SELECTION LASTRESULT
+	switch LASTRESULT
+	case 0, TakeEliteFourChallenge
+	case 1, EliteFourInfo
+	case 2, AttendantChoseNo
+    goto AttendantChoseNo
+
+TakeEliteFourChallenge:
+    @ Later, perform a check here for the champions flag
+    msgbox gText_AscensionTower_BattleTowerAttendant_NotChampion MSG_NORMAL
+    release
+    end
+
+EliteFourInfo:
+    msgbox gText_AscensionTower_EliteFourAttendant_NoChampionsFlag MSG_NORMAL
+    goto EventScript_AscensionTower_EliteFourAttendant
+
+AttendantChoseNo:
+    msgbox gText_AscensionTower_AttendantChoseNo MSG_NORMAL
+    release
+    end
+
+.global EventScript_AscensionTower_Blackbelt
+EventScript_AscensionTower_Blackbelt:
+    npcchat gText_AscensionTower_KarateMan
+    end
+
+.global EventScript_AscensionTower_Girl
+EventScript_AscensionTower_Girl:
+    npcchat gText_AscensionTower_Girl
+    end
+
+.global EventScript_AscensionTower_BigMan
+EventScript_AscensionTower_BigMan:
+    npcchat gText_AscensionTower_BigMan
+    end
+
+.global SignScript_AscensionTower_RecordsBoard
+SignScript_AscensionTower_RecordsBoard:
+    @ Later, show player's E4 and Battle Tower records
+    msgbox gText_AscensionTower_RecordsSign MSG_SIGN
+    end

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_facilities.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_facilities.s
@@ -9,6 +9,15 @@
 .equ FlagHideRival, 0x03C
 .equ SpriteRival, 0x2
 
+.global MapScript_DaimynFacilities_PokemonCenter
+MapScript_DaimynFacilities_PokemonCenter:
+    mapscript MAP_SCRIPT_ON_TRANSITION MapScript_DaimynFacilities_PokemonCenter_SetHealingSpot
+	.byte MAP_SCRIPT_TERMIN
+
+MapScript_DaimynFacilities_PokemonCenter_SetHealingSpot:
+    sethealingplace 0x06 @ Originally Vermillion City
+    end
+
 .global EventScript_DaimynCity_GuardHouseWest_Guard
 EventScript_DaimynCity_GuardHouseWest_Guard:
     msgbox gText_DaimynCityFacilities_GuardHouseWest_Guard MSG_NORMAL
@@ -87,7 +96,7 @@ RivalBattleCommon:
 
 .global EventScript_DaimynCityFacilities_RestaurauntBoy
 EventScript_DaimynCityFacilities_RestaurauntBoy:
-    npcchat gText_DaimynCityOverworld_RestaurantBoy
+    npcchat gText_DaimynCityFacilities_RestaurantBoy
     end
 
 .global EventScript_DaimynCityFacilities_RestaurauntBigMan
@@ -96,24 +105,39 @@ EventScript_DaimynCityFacilities_RestaurauntBigMan:
     faceplayer
     checkflag 0x24D @ Got leftovers
     If SET _goto LeftoversDescription
-    msgbox gText_DaimynCityOverworld_RestaurantBigMan MSG_NORMAL
+    msgbox gText_DaimynCityFacilities_RestaurantBigMan MSG_NORMAL
     obtainitem ITEM_LEFTOVERS 0x1
     setflag 0x24D @ Got Leftovers
     goto LeftoversDescription
 
 LeftoversDescription:
-    msgbox gText_DaimynCityOverworld_RestaurantBigMan_LeftoversDescription MSG_NORMAL
+    msgbox gText_DaimynCityFacilities_RestaurantBigMan_LeftoversDescription MSG_NORMAL
     release
     end
 
 .global EventScript_DaimynCityFacilities_RestaurauntGentleman
 EventScript_DaimynCityFacilities_RestaurauntGentleman:
-    msgbox gText_DaimynCityOverworld_RestaurantGentleman MSG_NORMAL
+    msgbox gText_DaimynCityFacilities_RestaurantGentleman MSG_NORMAL
     end
 
 .global EventScript_DaimynCityFacilities_RestaurauntGirl
 EventScript_DaimynCityFacilities_RestaurauntGirl:
-    npcchat gText_DaimynCityOverworld_RestaurantGirl
+    npcchat gText_DaimynCityFacilities_RestaurantGirl
+    end
+
+.global EventScript_DaimynCityFacilities_PokemonCenterOldWoman
+EventScript_DaimynCityFacilities_PokemonCenterOldWoman:
+    npcchat2 0x2 m_LookLeft gText_DaimynCityFacilities_PokemonCenter_OldWoman
+    end
+
+.global EventScript_DaimynCityFacilities_PokemonCenterWoman
+EventScript_DaimynCityFacilities_PokemonCenterWoman:
+    npcchat2 0x3 m_LookLeft gText_DaimynCityFacilities_PokemonCenter_Woman
+    end
+
+.global EventScript_DaimynCityFacilities_PokemonCenterGirl
+EventScript_DaimynCityFacilities_PokemonCenterGirl:
+    npcchat2 0x4 m_LookLeft gText_DaimynCityFacilities_PokemonCenter_Girl
     end
 
 m_RivalMeetsPlayer_West: .byte walk_right, walk_right, walk_right, walk_right, walk_right, walk_right, walk_right, end_m

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_npc_houses.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_npc_houses.s
@@ -1,0 +1,16 @@
+.thumb
+.align 2
+
+.include "../xse_commands.s"
+.include "../xse_defines.s"
+.include "../asm_defines.s"
+
+.global EventScript_DaimynCityNPCHouses_SuspiciousMan1
+EventScript_DaimynCityNPCHouses_SuspiciousMan1:
+    npcchat gText_DaimynCity_NPCHouses_SuspiciousMan1
+    end
+
+.global EventScript_DaimynCityNPCHouses_SuspiciousMan2
+EventScript_DaimynCityNPCHouses_SuspiciousMan2:
+    npcchat gText_DaimynCity_NPCHouses_SuspiciousMan2
+    end

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_overworld.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_overworld.s
@@ -14,7 +14,123 @@ MapEntryScript_DaimynCity_FlightSpot:
     setworldmapflag 0x895
     end
 
+.global EventScript_DaimynCityOverworld_GamblingMan
+EventScript_DaimynCityOverworld_GamblingMan:
+    npcchat gText_DaimynCityOverworld_GamblingMan
+    end
+
+.global EventScript_DaimynCityOverworld_Picknicker
+EventScript_DaimynCityOverworld_Picknicker:
+    npcchat gText_DaimynCityOverworld_Picknicker
+    end
+
+.global EventScript_DaimynCityOverworld_Hiker
+EventScript_DaimynCityOverworld_Hiker:
+    npcchat gText_DaimynCityOverworld_Hiker
+    end
+
+.global EventScript_DaimynCityOverworld_SuperNerd
+EventScript_DaimynCityOverworld_SuperNerd:
+    npcchat gText_DaimynCityOverworld_SuperNerd
+    end
+
+.global EventScript_DaimynCityOverworld_OldMan
+EventScript_DaimynCityOverworld_OldMan:
+    npcchat gText_DaimynCityOverworld_OldMan
+    end
+
+.global EventScript_DaimynCityOverworld_Boy
+EventScript_DaimynCityOverworld_Boy:
+    npcchat gText_DaimynCityOverworld_Boy
+    end
+
+.global EventScript_DaimynCityOverworld_Biker
+EventScript_DaimynCityOverworld_Biker:
+    npcchat gText_DaimynCityOverworld_Biker
+    end
+
+.global EventScript_DaimynCityOverworld_Girl
+EventScript_DaimynCityOverworld_Girl:
+    npcchat gText_DaimynCityOverworld_Girl
+    end
+
+.global EventScript_DaimynCityOverworld_Policeman
+EventScript_DaimynCityOverworld_Policeman:
+    npcchat gText_DaimynCityOverworld_Policeman
+    end
+
+.global EventScript_DaimynCityOverworld_PlutoNW
+EventScript_DaimynCityOverworld_PlutoNW:
+    npcchat gText_DaimynCityOverworld_PlutoNW
+    end
+
+.global EventScript_DaimynCityOverworld_PlutoSE
+EventScript_DaimynCityOverworld_PlutoSE:
+    npcchat gText_DaimynCityOverworld_PlutoSE
+    end
+
+.global EventScript_DaimynCityOverworld_PlutoSW
+EventScript_DaimynCityOverworld_PlutoSW:
+    npcchat gText_DaimynCityOverworld_PlutoSW
+    end
+
+.global EventScript_DaimynCity_FindTM46Thief
+EventScript_DaimynCity_FindTM46Thief:
+    setvar CHOSEN_ITEM ITEM_TM46
+    call ItemScript_Common_FindTM
+    end
+
 .global SignScript_DaimynCityOverworld_Restaurant
 SignScript_DaimynCityOverworld_Restaurant:
     msgbox gText_DaimynCityOverworld_RestaurantSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_AscensionTower
+SignScript_DaimynCityOverworld_AscensionTower:
+    msgbox gText_DaimynCityOverworld_AscensionTowerSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_ShoppingMall
+SignScript_DaimynCityOverworld_ShoppingMall:
+    msgbox gText_DaimynCityOverworld_ShoppingMallSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_LanasHouse
+SignScript_DaimynCityOverworld_LanasHouse:
+    msgbox gText_DaimynCityOverworld_LanasHouseSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_Gym
+SignScript_DaimynCityOverworld_Gym:
+    msgbox gText_DaimynCityOverworld_GymSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_InterdimensionalResearchLab
+SignScript_DaimynCityOverworld_InterdimensionalResearchLab:
+    msgbox gText_DaimynCityOverworld_InterdimensionalResearchLabSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_GuardHouseNorth
+SignScript_DaimynCityOverworld_GuardHouseNorth:
+    msgbox gText_DaimynCityOverworld_GuardHouseNorthSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_GuardHouseWest
+SignScript_DaimynCityOverworld_GuardHouseWest:
+    msgbox gText_DaimynCityOverworld_GuardHouseWestSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_GuardHouseEast
+SignScript_DaimynCityOverworld_GuardHouseEast:
+    msgbox gText_DaimynCityOverworld_GuardHouseEastSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_GuardHouseSouth
+SignScript_DaimynCityOverworld_GuardHouseSouth:
+    msgbox gText_DaimynCityOverworld_GuardHouseSouthSign MSG_SIGN
+    end
+
+.global SignScript_DaimynCityOverworld_DaimynCityPlacard
+SignScript_DaimynCityOverworld_DaimynCityPlacard:
+    msgbox gText_DaimynCityOverworld_CityPlacardSign MSG_SIGN
     end

--- a/eventscripts
+++ b/eventscripts
@@ -803,12 +803,54 @@ npc 9 3 0 EventScript_DaimynCity_GuardHouseWest_Guard
 tile 9 3 0 TileScript_DaimynCity_GuardHouseWest_TriggerRival
 npc 9 6 0 EventScript_DaimynCity_GuardHouseSouth_Guard
 tile 9 6 0 TileScript_DaimynCity_GuardHouseSouth_TriggerRival
+## Ascension Tower
+map 2 10 MapScript_AscensionTower
+npc 2 10 0 EventScript_PokemonCenter_Main
+npc 2 10 1 EventScript_AscensionTower_BattleTowerAttendant
+npc 2 10 2 EventScript_AscensionTower_EliteFourAttendant
+npc 2 10 3 EventScript_AscensionTower_Blackbelt
+npc 2 10 4 EventScript_AscensionTower_Girl
+npc 2 10 5 EventScript_AscensionTower_BigMan
+sign 2 10 0 SignScript_AscensionTower_RecordsBoard
 ## Overworld
 map 3 5 MapScript_DaimynCity
+npc 3 5 0 EventScript_DaimynCityOverworld_GamblingMan
+npc 3 5 1 EventScript_DaimynCityOverworld_Picknicker
+npc 3 5 2 EventScript_DaimynCityOverworld_Hiker
+npc 3 5 3 EventScript_DaimynCityOverworld_SuperNerd
+npc 3 5 4 EventScript_DaimynCityOverworld_OldMan
+npc 3 5 5 EventScript_DaimynCityOverworld_Boy
+npc 3 5 6 EventScript_DaimynCityOverworld_Biker
+npc 3 5 7 EventScript_DaimynCityOverworld_Girl
+npc 3 5 8 EventScript_DaimynCityOverworld_Policeman
+npc 3 5 9 EventScript_DaimynCityOverworld_PlutoNW
+npc 3 5 10 EventScript_DaimynCityOverworld_PlutoSE
+npc 3 5 11 EventScript_DaimynCityOverworld_PlutoSW
+npc 3 5 12 EventScript_Common_Cut
+npc 3 5 13 EventScript_DaimynCity_FindTM46Thief
 sign 3 5 0 SignScript_DaimynCityOverworld_Restaurant
+sign 3 5 1 SignScript_DaimynCityOverworld_AscensionTower
+sign 3 5 2 SignScript_DaimynCityOverworld_ShoppingMall
+sign 3 5 3 SignScript_DaimynCityOverworld_LanasHouse
+sign 3 5 4 SignScript_DaimynCityOverworld_Gym
+sign 3 5 5 SignScript_DaimynCityOverworld_InterdimensionalResearchLab
+sign 3 5 6 SignScript_DaimynCityOverworld_GuardHouseNorth
+sign 3 5 7 SignScript_DaimynCityOverworld_GuardHouseWest
+sign 3 5 8 SignScript_DaimynCityOverworld_GuardHouseEast
+sign 3 5 9 SignScript_DaimynCityOverworld_GuardHouseSouth
+### Sign 10 is a hidden item
+sign 3 5 11 SignScript_DaimynCityOverworld_DaimynCityPlacard
 ## Facilities
+map 9 9 MapScript_DaimynFacilities_PokemonCenter
 npc 9 8 0 EventScript_DaimynRestaurant_Chef
 npc 9 8 1 EventScript_DaimynCityFacilities_RestaurauntBoy
 npc 9 8 2 EventScript_DaimynCityFacilities_RestaurauntBigMan
 npc 9 8 3 EventScript_DaimynCityFacilities_RestaurauntGentleman
 npc 9 8 4 EventScript_DaimynCityFacilities_RestaurauntGirl
+npc 9 9 0 EventScript_PokemonCenter_Main
+npc 9 9 1 EventScript_DaimynCityFacilities_PokemonCenterOldWoman
+npc 9 9 2 EventScript_DaimynCityFacilities_PokemonCenterWoman
+npc 9 9 3 EventScript_DaimynCityFacilities_PokemonCenterGirl
+## NPC Houses
+npc 9 10 0 EventScript_DaimynCityNPCHouses_SuspiciousMan1
+npc 9 10 1 EventScript_DaimynCityNPCHouses_SuspiciousMan2

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -449,7 +449,7 @@
 #define FLAG_HIDE_FORGOTTEN_MANSE_2F_TM60_HEX                   0x1B7
 #define FLAG_HIDE_FORGOTTEN_MANSE_BF1_TM61_WILL_O_WISP          0x1B8
 #define FLAG_HIDE_FORGOTTEN_MANSE_1F_SABLENITE                  0x1B9
-#define FLAG_HIDE_TWO_ISLAND_REVIVE                             0x1BA
+#define FLAG_HIDE_DAIMYN_CITY_TM46_THIEF                        0x1BA
 #define FLAG_HIDE_THREE_ISLAND_ZINC                             0x1BB
 #define FLAG_0x1BC                                              0x1BC
 #define FLAG_0x1BD                                              0x1BD
@@ -1070,7 +1070,7 @@
 #define HIDDEN_ITEM_FORGOTTEN_MANSE_AGUAV_BERRY                        41
 #define HIDDEN_ITEM_FORGOTTEN_MANSE_SMOKE_BALL                         42
 #define HIDDEN_ITEM_FORGOTTEN_MANSE_ESCAPE_ROPE                        43
-#define HIDDEN_ITEM_UNUSED_0x2C                                        44
+#define HIDDEN_ITEM_DAIMYN_CITY_ULTRA_BALL                             44
 #define HIDDEN_ITEM_UNUSED_0x2D                                        45
 #define HIDDEN_ITEM_UNUSED_0x2E                                        46
 #define HIDDEN_ITEM_CELADON_CITY_PP_UP                                 47

--- a/strings/general_battle_strings.string
+++ b/strings/general_battle_strings.string
@@ -6,7 +6,7 @@
 [FD][13] is benefitting from a meal!
 
 #org @BattleText_MealEffectEnded
-[FD][13]'s meal effect has ended.
+[FD][13]'s meal effect has ended.[PAUSE_UNTIL_PRESS]
 
 #org @BattleText_TwoTrainersWantToBattle
 You are challenged by\n[FD][1C] [FD][1D] and\l[FD][2E] [FD][2F]!\p

--- a/strings/scripts/common/common.string
+++ b/strings/scripts/common/common.string
@@ -25,6 +25,15 @@ Sleep
 #org @gText_End
 End
 
+#org @gText_Yes
+Yes
+
+#org @gText_No
+No
+
+#org @gText_Info
+Info
+
 #org @gText_ReceiveRunningShoes
 [BLACK][PLAYER] obtained the Running Shoes!
 

--- a/strings/scripts/daimyn_city/ascension_tower.string
+++ b/strings/scripts/daimyn_city/ascension_tower.string
@@ -1,0 +1,32 @@
+#org @gText_AscensionTower_EliteFourAttendant_Introduction
+Welcome to Ascension Tower! I accept\nregistrations for the Elite Four\lchallenge.\pWould you like to take the Elite\nFour challenge?
+
+#org @gText_AscensionTower_EliteFourAttendant_NoChampionsFlag
+Please present your Champion's Flag\nand I'll get you registered[.]\pOh! You don't have one. Please\nreturn when you have one.\pOne is conferred upon you by a\nmember of the Elite Four after\lsuccessfully reaching the end of\lVictory Road.
+
+#org @gText_AscensionTower_EliteFourAttendant_ChallengeInfo
+Trainers who have obtained a\nChampion's Flag may challenge the\lElite Four Challenge.\pApplicants must battle four of the\nKulure region's best trainers in a\lback-to-back gauntlet.\pIf successful, they will obtain the\nright to challenge the Champion for\ltheir title!
+
+#org @gText_AscensionTower_BattleTowerAttendant_Introduction
+Welcome to Ascension Tower! I accept\nregistrations for the Battle Tower\lchallenge.\pWould you like to take the Battle\nTower challenge?
+
+#org @gText_AscensionTower_EliteFourAttendant_BattleTowerInfo
+Trainers who have become Gym\nLeaders, Elite Four members, or\lthe Champion are eligible to\lpartake in the Battle Tower\lchallenge.\pThese trainers may choose 3 Pok\emon\nwith which they will battle as many\ltrainers as possible.\pUpon losing, they will be awarded\nbattle points (BP) based on their\lperformance.\pBP can be traded for exciting prizes\nthat can't be found elsewhere.
+
+#org @gText_AscensionTower_BattleTowerAttendant_NotChampion
+Oh, my apologies. You must be a Gym\nLeader, Elite Four member, or the\lChampion to partake in this\lchallenge.\pPlease see me again if you attain\nany of these titles.
+
+#org @gText_AscensionTower_AttendantChoseNo
+Understood. Please speak to me again\nif you change your mind.
+
+#org @gText_AscensionTower_KarateMan
+Wrrrrooooaaaggghhh!\pI almost beat Liam this time. I'll\ntrain up and wipe that smug grin\loff his face, just you wait and\lsee.
+
+#org @gText_AscensionTower_Girl
+I like coming here to watch the\nElite Four challengers battle!\pEveryone gives it their all, and it\nleads to really exciting battles.
+
+#org @gText_AscensionTower_BigMan
+My son dreams of becoming the\nChampion. It's all he talks about.\pI thought I'd come here to see what\nit's all about.\pThis Champion is seriously strong! I'd\nbetter help him train so he can do\lhis best.
+
+#org @gText_AscensionTower_RecordsSign
+It's a board showing the records\nof all the trainers who've\lchallenged the Elite Four and\lBattle Tower.\pMaybe someday I'll be on here!

--- a/strings/scripts/daimyn_city/daimyn_city_facilities.string
+++ b/strings/scripts/daimyn_city/daimyn_city_facilities.string
@@ -25,17 +25,26 @@ Aw, that's another loss for me.
 #org @gText_DaimynCityFacilities_GuardHouse_RivalOffersTourOfDaimynCity
 [BLUE]Hey, I have an idea. We're right\noutside Daimyn City, right?\pWhy don't we walk through the city\ntogether to the Pok\emon Center?\pI know a lot about the city.\nIt'll be fun! Let's go!
 
-#org @gText_DaimynCityOverworld_RestaurantBoy
+#org @gText_DaimynCityFacilities_RestaurantBoy
 My grandpa takes me out for lunch\nevery week. It's a nice opportunity\lto catch up and chat!
 
-#org @gText_DaimynCityOverworld_RestaurantBigMan
+#org @gText_DaimynCityFacilities_RestaurantBigMan
 Urp[.] I think I ate too much[.]\nMy stomach hurts.\pIf I can't finish my meal, they'll\nmake me pay double!\pHey, you!\pYou'll take my [GREEN]Leftovers[BLUE], won't you?
 
-#org @gText_DaimynCityOverworld_RestaurantBigMan_LeftoversDescription
+#org @gText_DaimynCityFacilities_RestaurantBigMan_LeftoversDescription
 If you give your Pok\emon those\nLeftovers to hold, they'll restore\lHP every turn.\pHandy, right?
 
-#org @gText_DaimynCityOverworld_RestaurantGentleman
+#org @gText_DaimynCityFacilities_RestaurantGentleman
 You can order what ever you'd like,\nmy boy. Hohoho!
 
-#org @gText_DaimynCityOverworld_RestaurantGirl
+#org @gText_DaimynCityFacilities_RestaurantGirl
 Hmm[.] What should I order? Everything\nlooks so good.
+
+#org @gText_DaimynCityFacilities_PokemonCenter_OldWoman
+My friends and I organize a shopping\ntrip in Daimyn City every year.\pThere are a lot of really great\nsales on right now.\pI'm just waiting for them to arrive\nbefore I head out.
+
+#org @gText_DaimynCityFacilities_PokemonCenter_Woman
+My husband just disappeared on me\nand left me with our daughter.\pHe better not have run off to the\ncasino again[.]
+
+#org @gText_DaimynCityFacilities_PokemonCenter_Girl
+My mommy and I are waiting for daddy\nto come back.\pMommy said he's going to bring us\nCastelicones! I can't wait!

--- a/strings/scripts/daimyn_city/daimyn_city_npc_houses.string
+++ b/strings/scripts/daimyn_city/daimyn_city_npc_houses.string
@@ -1,0 +1,5 @@
+#org @gText_DaimynCity_NPCHouses_SuspiciousMan1
+We're just minding our own business.\pWhy don't you get lost and play with\nyour Pok\emon or something?
+
+#org @gText_DaimynCity_NPCHouses_SuspiciousMan2
+Our house is really basic. There's\nnothing interesting about it our our\llives.

--- a/strings/scripts/daimyn_city/daimyn_city_overworld.string
+++ b/strings/scripts/daimyn_city/daimyn_city_overworld.string
@@ -1,2 +1,68 @@
+#org @gText_DaimynCityOverworld_GamblingMan
+Shhh! Don't tell anyone you found me\nhere.\pI lost it all at the Daimyn City\ngym[.] I can't face my family after\lthis.
+
+#org @gText_DaimynCityOverworld_Picknicker
+Isn't the Daimyn City garden\npretty?\pIt attracts a lot of interesting\nPok\emon.
+
+#org @gText_DaimynCityOverworld_Hiker
+I'm going to hike to Bruccie\nVillage soon.\pThe road there is difficult and\nrugged, and most people can't\lmanage it.\pIt's important to take the time to\nprepare before going on any\ldangerous journies.
+
+#org @gText_DaimynCityOverworld_SuperNerd
+Daimyn City is the largest city in\nKulure! It's quite the spectacle,\lisn't it?\pA lot of powerful trainers gather\nhere to challenge the Elite Four\land try to take the Champion's\ltitle.\pThey haven't succeeded since Selene\nbecame Champion, but that won't\lstop them from trying!
+
+#org @gText_DaimynCityOverworld_OldMan
+The Daimyn City gym doubles as both\na gym and a casino!\pIt attracts all sorts of people and\nis always bustling.\pThe leader, Chance, is an old friend\nof mine.\pBe careful if you find yourself\nfacing him both in battle and at\lthe game table! Ha ha ha!
+
+#org @gText_DaimynCityOverworld_Boy
+I saw Champion Selene the other\nday! She looked really busy\lthough.
+
+#org @gText_DaimynCityOverworld_Biker
+Daimyn City's roads are all concrete\nand tile.\pIt's perfect for a road hog like me!\nGwah hah hah!
+
+#org @gText_DaimynCityOverworld_Girl
+Daimyn City is a central hub that\nconnects many routes.\pYou could make your way to many\ndifferent towns from here!
+
+#org @gText_DaimynCityOverworld_Policeman
+There have been more Team Pluto\nmembers around here lately.\pThey're careful not to do anything\nthat'll get them in trouble, so my\lhands are tied[.]\pJust[.] Don't hang out around them too\nmuch, okay? They're a bad\linfluence.
+
+#org @gText_DaimynCityOverworld_PlutoNW
+Hey, beat it, kid! I'm not botherin'\nanyone here.
+
+#org @gText_DaimynCityOverworld_PlutoSE
+Hey, kid! You'll give me your\nPok\emon, right?\pNo? Agh, get lost!
+
+#org @gText_DaimynCityOverworld_PlutoSW
+Why are there so many members of\nteam Pluto in the city? That's a\lsecret!
+
 #org @gText_DaimynCityOverworld_RestaurantSign
 Daimyn City Restaurant\nDelicious meals for Pok\emon!
+
+#org @gText_DaimynCityOverworld_AscensionTowerSign
+Ascension Tower:\nHome of Kulure's Finest Trainers
+
+#org @gText_DaimynCityOverworld_ShoppingMallSign
+Daimyn Shopping Center:\nFind your new favorite item today!
+
+#org @gText_DaimynCityOverworld_LanasHouseSign
+Lana's Lab: Home of the Kulure PC\nExpansion Effort
+
+#org @gText_DaimynCityOverworld_GymSign
+Daimyn City Pok\emon Gym\nLeader: Chance\lThe High Roller Risk Taker!
+
+#org @gText_DaimynCityOverworld_InterdimensionalResearchLabSign
+Interdimensional Research Lab:\nExploring the frontiers of Ultra\lSpace
+
+#org @gText_DaimynCityOverworld_GuardHouseNorthSign
+North: Route 9
+
+#org @gText_DaimynCityOverworld_GuardHouseWestSign
+West: Route 8
+
+#org @gText_DaimynCityOverworld_GuardHouseEastSign
+East: Route 10
+
+#org @gText_DaimynCityOverworld_GuardHouseSouthSign
+South: Route 6
+
+#org @gText_DaimynCityOverworld_CityPlacardSign
+Daimyn City: The Hustling Metropolis


### PR DESCRIPTION
Adds events to:
* Daimyn City overworld
* Daimyn City NPC houses
* Daimyn City Pokemon Center
* Ascension Tower

Also improves the restaurant meal effect message. When it wears off after battle, you now must press a button for the message to clear, instead of it happening automatically.