### PR TITLE
fix favorit gen dialog

### DIFF
--- a/assembly/overworld_scripts/anthra_town/anthra_town.s
+++ b/assembly/overworld_scripts/anthra_town/anthra_town.s
@@ -197,24 +197,20 @@ LevelScript_GenChoice_Main:
 
 EventScript_GenChoice_Favoritegen:
 	msgbox gText_GenChoice_Msgfavoritegen MSG_KEEPOPEN
-	multichoice 0x0 0x0 0x1 0x1
-	copyvar 0x408C LASTRESULT
-	compare 0x408C 0x0
-	if TRUE _call EventScript_GenChoice_Kantoconfirm
-	compare 0x408C 0x1
-	if TRUE _call EventScript_GenChoice_Johtoconfirm
-	compare 0x408C 0x2
-	if TRUE _call EventScript_GenChoice_Hoennconfirm
-	compare 0x408C 0x3
-	if TRUE _call EventScript_GenChoice_Sinnohconfirm
-	compare 0x408C 0x4
-	if TRUE _call EventScript_GenChoice_Unovaconfirm
-	compare 0x408C 0x5
-	if TRUE _call EventScript_GenChoice_Kalosconfirm
-	compare 0x408C 0x6
-	if TRUE _call EventScript_GenChoice_Alolaconfirm
-	compare 0x408C 0x7
-	if TRUE _call EventScript_GenChoice_Galarconfirm
+	setvar 0x8000 0x5
+    setvar 0x8001 0x4
+    setvar 0x8004 0x0
+	special 0x158
+    waitstate
+    switch LASTRESULT
+	case 0, EventScript_GenChoice_Kantoconfirm
+	case 1, EventScript_GenChoice_Johtoconfirm
+	case 2, EventScript_GenChoice_Hoennconfirm
+	case 3, EventScript_GenChoice_Sinnohconfirm
+	case 4, EventScript_GenChoice_Unovaconfirm
+	case 5, EventScript_GenChoice_Kalosconfirm
+	case 6, EventScript_GenChoice_Alolaconfirm
+	case 7, EventScript_GenChoice_Galarconfirm
 	end
 
 EventScript_GenChoice_Shuffle:
@@ -233,6 +229,7 @@ EventScript_GenChoice_Shuffle:
 EventScript_GenChoice_Kantoconfirm:
 	msgbox gText_GenChoice_Msgkantoconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x0
 	setvar 0x408D 0x0
 	setvar 0x408E 0x0
 	call EventScript_GenChoice_End
@@ -240,6 +237,7 @@ EventScript_GenChoice_Kantoconfirm:
 EventScript_GenChoice_Johtoconfirm:
 	msgbox gText_GenChoice_Msgjohtoconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x1
 	setvar 0x408D 0x1
 	setvar 0x408E 0x1
 	call EventScript_GenChoice_End
@@ -247,6 +245,7 @@ EventScript_GenChoice_Johtoconfirm:
 EventScript_GenChoice_Hoennconfirm:
 	msgbox gText_GenChoice_Msghoennconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x2
 	setvar 0x408D 0x2
 	setvar 0x408E 0x2
 	call EventScript_GenChoice_End
@@ -254,6 +253,7 @@ EventScript_GenChoice_Hoennconfirm:
 EventScript_GenChoice_Sinnohconfirm:
 	msgbox gText_GenChoice_Msgsinnohconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x3
 	setvar 0x408D 0x3
 	setvar 0x408E 0x3
 	call EventScript_GenChoice_End
@@ -261,6 +261,7 @@ EventScript_GenChoice_Sinnohconfirm:
 EventScript_GenChoice_Unovaconfirm:
 	msgbox gText_GenChoice_Msgunovaconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x4
 	setvar 0x408D 0x4
 	setvar 0x408E 0x4
 	call EventScript_GenChoice_End
@@ -268,6 +269,7 @@ EventScript_GenChoice_Unovaconfirm:
 EventScript_GenChoice_Kalosconfirm:
 	msgbox gText_GenChoice_Msgkalosconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x5
 	setvar 0x408D 0x5
 	setvar 0x408E 0x5
 	call EventScript_GenChoice_End
@@ -275,6 +277,7 @@ EventScript_GenChoice_Kalosconfirm:
 EventScript_GenChoice_Alolaconfirm:
 	msgbox gText_GenChoice_Msgalolaconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x6
 	setvar 0x408D 0x6
 	setvar 0x408E 0x6
 	call EventScript_GenChoice_End
@@ -282,6 +285,7 @@ EventScript_GenChoice_Alolaconfirm:
 EventScript_GenChoice_Galarconfirm:
 	msgbox gText_GenChoice_Msggalarconfirm MSG_YESNO
 	call EventScript_GenChoice_Genchoiceconfirm
+	setvar 0x408C 0x7
 	setvar 0x408D 0x7
 	setvar 0x408E 0x7
 	call EventScript_GenChoice_End
@@ -293,6 +297,8 @@ EventScript_GenChoice_Genchoiceconfirm:
 
 EventScript_GenChoice_Reset:
 	setvar 0x408C 0x0
+	setvar 0x408D 0x0
+	setvar 0x408E 0x0
 	call LevelScript_GenChoice_Main
 
 EventScript_GenChoice_End:

--- a/src/scripting.c
+++ b/src/scripting.c
@@ -2967,6 +2967,16 @@ extern const u8 gText_FoodAccuracy[];
 extern const u8 gText_FoodEvasion[];
 extern const u8 gText_FoodAll[];
 
+// Favorite Regions
+extern const u8 gText_RegionKanto[];
+extern const u8 gText_RegionJohto[];
+extern const u8 gText_RegionHoenn[];
+extern const u8 gText_RegionSinnoh[];
+extern const u8 gText_RegionUnova[];
+extern const u8 gText_RegionKalos[];
+extern const u8 gText_RegionAlola[];
+extern const u8 gText_RegionGalar[];
+
 //Scrolling Lists
 static const u8* sTutorFerrox[] =
 {
@@ -3032,6 +3042,18 @@ static const u8* sMealOptionsWithAll[] =
 	gText_End,  
 };
 
+static const u8* sFavoriteRegion[] =
+{
+	gText_RegionKanto,
+	gText_RegionJohto,
+	gText_RegionHoenn,
+	gText_RegionSinnoh,
+	gText_RegionUnova,
+	gText_RegionKalos,
+	gText_RegionAlola,
+	gText_RegionGalar,
+};
+
 // Multichoice Lists
 const struct ScrollingMulti gScrollingSets[] =
 {
@@ -3040,6 +3062,7 @@ const struct ScrollingMulti gScrollingSets[] =
 	{sMealOptions, ARRAY_COUNT(sMealOptions)},
 	{sMealOptionsWithAll, ARRAY_COUNT(sMealOptionsWithAll)},
 	{sTutorDaimyn, ARRAY_COUNT(sTutorDaimyn)},
+	{sFavoriteRegion, ARRAY_COUNT(sFavoriteRegion)},
 };
 
 //Link number of opts shown at once to the box height

--- a/strings/scrolling_multichoice.string
+++ b/strings/scrolling_multichoice.string
@@ -98,4 +98,28 @@ Pain Split
 #org @gText_FoodAll
 [GREEN](All)[BLACK][ALIGN][50]Rare Candy Cake
 
+#org @gText_RegionKanto
+Kanto
+
+#org @gText_RegionJohto
+Johto
+
+#org @gText_RegionHoenn
+Hoenn
+
+#org @gText_RegionSinnoh
+Sinnoh
+
+#org @gText_RegionUnova
+Unova
+
+#org @gText_RegionKalos
+Kalos
+
+#org @gText_RegionAlola
+Alola
+
+#org @gText_RegionGalar
+Galar
+
 #endif


### PR DESCRIPTION
Fix bugs in the favorite gen dialog:

- Now uses a scrolling multichoice, to not overlap with textbox.
- Fixes an embarrassing bug where the grass starter was not set when choosing a region directly