### PR TITLE
Fix broken honey item

### DIFF
--- a/assembly/overworld_scripts/common/pokemart.s
+++ b/assembly/overworld_scripts/common/pokemart.s
@@ -78,6 +78,7 @@ NoBadges_Stock:
     .hword ITEM_ICE_HEAL
     .hword ITEM_AWAKENING
     .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_NONE
 
@@ -90,6 +91,7 @@ OneBadge_Stock:
     .hword ITEM_ICE_HEAL
     .hword ITEM_AWAKENING
     .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE
@@ -105,6 +107,7 @@ TwoBadges_Stock:
     .hword ITEM_ICE_HEAL
     .hword ITEM_AWAKENING
     .hword ITEM_PARALYZE_HEAL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE
@@ -121,6 +124,7 @@ ThreeBadges_Stock:
     .hword ITEM_AWAKENING
     .hword ITEM_PARALYZE_HEAL
     .hword ITEM_REPEL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE
@@ -138,6 +142,7 @@ FourBadges_Stock:
     .hword ITEM_AWAKENING
     .hword ITEM_PARALYZE_HEAL
     .hword ITEM_REPEL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE
@@ -157,6 +162,7 @@ FiveBadges_Stock:
     .hword ITEM_PARALYZE_HEAL
     .hword ITEM_REPEL
     .hword ITEM_SUPER_REPEL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE
@@ -177,6 +183,7 @@ SixBadges_Stock:
     .hword ITEM_FULL_HEAL
     .hword ITEM_REPEL
     .hword ITEM_SUPER_REPEL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE
@@ -199,6 +206,7 @@ SevenBadges_Stock:
     .hword ITEM_REPEL
     .hword ITEM_SUPER_REPEL
     .hword ITEM_MAX_REPEL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE
@@ -222,6 +230,7 @@ EightBadges_Stock:
     .hword ITEM_REPEL
     .hword ITEM_SUPER_REPEL
     .hword ITEM_MAX_REPEL
+    .hword ITEM_HONEY
     .hword ITEM_REVIVE
     .hword ITEM_ESCAPE_ROPE
     .hword ITEM_NONE

--- a/assembly/overworld_scripts/rhodanzi_city/rhodanzi_overworld.s
+++ b/assembly/overworld_scripts/rhodanzi_city/rhodanzi_overworld.s
@@ -99,6 +99,11 @@ EventScript_RhodanziOverworld_PokeChipMan:
     npcchat gText_RhodanziOverworld_PokeChipMan
     end
 
+.global EventScript_RhodanziOverworld_HoneyMan
+EventScript_RhodanziOverworld_HoneyMan:
+    npcchat gText_RhodanziOverworld_Honey
+    end
+
 m_ThugTopMoveToPush:
     .byte run_right, run_down, look_left, end_m
 

--- a/eventscripts
+++ b/eventscripts
@@ -139,6 +139,7 @@ npc 3 2 6 EventScript_RhodanziOverworld_ThugTopSpokenTo
 npc 3 2 7 ItemScript_Common_SodaPop
 npc 3 2 8 EventScript_RhodanziOverworld_FindTMEchoedVoice
 npc 3 2 9 EventScript_RhodanziOverworld_PokeChipMan
+npc 3 2 10 EventScript_RhodanziOverworld_HoneyMan
 sign 3 2 1 SignScript_RhodanziCity_EntranceSign
 sign 3 2 3 SignScript_RhodanziCity_FishermanSign
 tile 3 2 0 TileScript_RhodanziOverworld_ThugsCaught

--- a/routinepointers
+++ b/routinepointers
@@ -279,6 +279,8 @@ FieldUseFunc_FormChangeItem 873371C
 FieldUseFunc_FormChangeItem 8734C14
 FieldUseFunc_FormChangeItem 8734C40
 
+FieldUseFunc_Honey 872E788
+
 ## Stat reducing berries, in stat order (HP, Atk, Def, Sp Atk, Sp Def, Spd)
 FieldUseFunc_EVReducingBerry 872F574
 FieldUseFunc_EVReducingBerry 872F5A0

--- a/src/end_battle.c
+++ b/src/end_battle.c
@@ -952,13 +952,25 @@ bool8 IsConsumable(u16 item)
 void HandlePokeChip()
 {
 	bool8 hasPokeChipCharm = CheckBagHasItem(ITEM_POKE_CHIP_CHARM, 1) > 0;
-	bool8 foundPokeChip = Random() % 100 < (hasPokeChipCharm ? ENHANCED_POKE_CHIP_RATE : BASE_POKE_CHIP_RATE) + 1;
+	bool8 isHoneyOrSweetScent = FlagGet(FLAG_TEMP_1);
+
+	u8 baseRate = BASE_POKE_CHIP_RATE;
+	u8 enhancedRate = ENHANCED_POKE_CHIP_RATE;
+
+	if (isHoneyOrSweetScent)
+	{
+		baseRate += 15;
+		enhancedRate += 15;
+	}
+
+	bool8 foundPokeChip = Random() % 100 < (hasPokeChipCharm ? enhancedRate : baseRate) + 1;
 	if (foundPokeChip)
 	{
 		AddBagItem(ITEM_POKE_CHIP, 1);
 		gBattleStringLoader = gText_HoldingPokeChip;
 		PlaySE(MUS_FANFA1);
 	}
+	FlagClear(FLAG_TEMP_1);
 }
 
 void CheckForMealEffectEnd(void)

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2697,6 +2697,7 @@ static void Task_ChangeGigantamax(u8 taskId)
 static void Task_HoneyField(u8 taskId)
 {
 	SetWeatherScreenFadeOut();
+	FlagSet(FLAG_TEMP_1); // Activated Honey or Sweet Scent
 	StartSweetScentFieldEffect();
 	DestroyTask(taskId);	
 }

--- a/strings/scripts/rhodanzi_city/rhodanzi_overworld.string
+++ b/strings/scripts/rhodanzi_city/rhodanzi_overworld.string
@@ -30,3 +30,6 @@ Rhodanzi Fishing Committee
 
 #org @gText_RhodanziOverworld_PokeChipMan
 You may find a small fragment when\ndefeating wild Pok\emon.\pWe've called these 'Pok\eChips.' We\ndon't fully understand what they\lare yet, but collectors sure like\lthem!
+
+#org @gText_RhodanziOverworld_Honey
+Did you know? If you use Honey or\nthe Sweet Scent move, you can\linstantly trigger a battle.\pPok\emon encountered this way are\nmore likely to drop Pok\eChips!\pHoney can be bought at any Pok\e\nMart.


### PR DESCRIPTION
Fix broken honey item, and make it so activating a battle via honey or sweet scent makes you 15% more likely to get a pokechip.