### PR TITLE
Add updated exp share

### DIFF
--- a/routinepointers
+++ b/routinepointers
@@ -280,6 +280,7 @@ FieldUseFunc_FormChangeItem 8734C14
 FieldUseFunc_FormChangeItem 8734C40
 
 FieldUseFunc_Honey 872E788
+FieldUseFunc_ExpShare 872FA70
 
 ## Stat reducing berries, in stat order (HP, Atk, Def, Sp Atk, Sp Def, Spd)
 FieldUseFunc_EVReducingBerry 872F574

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2710,6 +2710,25 @@ void FieldUseFunc_Honey(u8 taskId)
 	SetUpItemUseOnFieldCallback(taskId);
 }
 
+extern const u8 gText_ExpShareTurnedOff[];
+extern const u8 gText_ExpShareTurnedOn[];
+
+void FieldUseFunc_ExpShare(u8 taskId)
+{
+	if (FlagGet(FLAG_EXP_SHARE))
+	{
+		PlaySE(SE_PC_OFF);
+		FlagClear(FLAG_EXP_SHARE);
+		DisplayItemMessageInBag(taskId, 2, gText_ExpShareTurnedOff, Task_ReturnToBagFromContextMenu);
+	}
+	else
+	{
+		PlaySE(SE_PC_ON);
+		FlagSet(FLAG_EXP_SHARE);
+		DisplayItemMessageInBag(taskId, 2, gText_ExpShareTurnedOn, Task_ReturnToBagFromContextMenu);
+	}	
+}
+
 extern u8 GetCurrentLevelCap(void); //Must be implemented yourself
 void ItemUseCB_RareCandy(u8 taskId, TaskFunc func)
 {

--- a/strings/general_battle_script_strings.string
+++ b/strings/general_battle_script_strings.string
@@ -381,7 +381,7 @@ The mysterious strong winds\ncontinue to blow.
 One [LAST_ITEM] was taken from\n[BUFFER][00] and placed in the Bag.
 
 #org @gText_HoldingPokeChip
-[TARGET] was holding a\nPok\eChip! Placed it in the Bag.
+[TARGET] was holding a\nPok\eChip! Placed it in the Bag.[PAUSE_UNTIL_PRESS]
 
 #org @gText_TookCaughtItemToCube
 One [LAST_ITEM] was taken from\n[BUFFER][00] and placed in the Cube.

--- a/strings/party_menu.string
+++ b/strings/party_menu.string
@@ -72,3 +72,9 @@ Change [BUFFER1]'s nickname?
 
 #org @gText_NicknameChanged
 [BUFFER1]'s nickname has been changed![PAUSE_UNTIL_PRESS]
+
+#org @gText_ExpShareTurnedOff
+The Exp. Share was turned off.[PAUSE_UNTIL_PRESS]
+
+#org @gText_ExpShareTurnedOn
+The Exp. Share was turned on.[PAUSE_UNTIL_PRESS]


### PR DESCRIPTION
Update the exp share to gen 6 standard, and make it toggleable via the key items menu.