### PR TITLE
Show button press indicator for certain custom battle strings

### DIFF
--- a/strings/general_battle_script_strings.string
+++ b/strings/general_battle_script_strings.string
@@ -381,7 +381,7 @@ The mysterious strong winds\ncontinue to blow.
 One [LAST_ITEM] was taken from\n[BUFFER][00] and placed in the Bag.
 
 #org @gText_HoldingPokeChip
-[TARGET] was holding a\nPok\eChip! Placed it in the Bag.[PAUSE_UNTIL_PRESS]
+[TARGET] was holding a\nPok\eChip! Placed it in the Bag.\p
 
 #org @gText_TookCaughtItemToCube
 One [LAST_ITEM] was taken from\n[BUFFER][00] and placed in the Cube.

--- a/strings/general_battle_strings.string
+++ b/strings/general_battle_strings.string
@@ -6,7 +6,7 @@
 [FD][13] is benefitting from a meal!
 
 #org @BattleText_MealEffectEnded
-[FD][13]'s meal effect has ended.[PAUSE_UNTIL_PRESS]
+[FD][13]'s meal effect has ended.\p
 
 #org @BattleText_TwoTrainersWantToBattle
 You are challenged by\n[FD][1C] [FD][1D] and\l[FD][2E] [FD][2F]!\p


### PR DESCRIPTION
Update custom battle text to be consistent, when deciding whether a "button press" arrow should display or not