### PR TITLE
Obedience messages based on badge count

### DIFF
--- a/assembly/overworld_scripts/bruccie_village/bruccie_village_gym.s
+++ b/assembly/overworld_scripts/bruccie_village/bruccie_village_gym.s
@@ -59,11 +59,11 @@ EventScript_BruccieVillageGym_Abby:
 
 EventScript_BruccieVillageGym_LeaderAbby_Defeated:
     msgbox gText_BruccieVillageGym_LeaderAbby_BadgeAwarded MSG_NORMAL
+    setflag 0x825 @ Bruccie Village gym badge
     fanfare 0x13D @ Gym victory
     msgbox gText_BruccieVillageGym_BadgeReceived MSG_NORMAL
     call BadgeObedienceMessage
     waitfanfare
-    setflag 0x825 @ Bruccie Village gym badge
     msgbox gText_BruccieVillageGym_LeaderAbby_BadgeDescription MSG_NORMAL
     msgbox gText_BruccieVillageGym_LeaderAbby_TMReceived MSG_NORMAL
     loadpointer 0x0 gText_BruccieVillageGym_TMReceived

--- a/assembly/overworld_scripts/bruccie_village/bruccie_village_gym.s
+++ b/assembly/overworld_scripts/bruccie_village/bruccie_village_gym.s
@@ -60,7 +60,8 @@ EventScript_BruccieVillageGym_Abby:
 EventScript_BruccieVillageGym_LeaderAbby_Defeated:
     msgbox gText_BruccieVillageGym_LeaderAbby_BadgeAwarded MSG_NORMAL
     fanfare 0x13D @ Gym victory
-    msgbox gText_BruccieVillageGym_BadgeReceived MSG_KEEPOPEN
+    msgbox gText_BruccieVillageGym_BadgeReceived MSG_NORMAL
+    call BadgeObedienceMessage
     waitfanfare
     setflag 0x825 @ Bruccie Village gym badge
     msgbox gText_BruccieVillageGym_LeaderAbby_BadgeDescription MSG_NORMAL

--- a/assembly/overworld_scripts/common/common.s
+++ b/assembly/overworld_scripts/common/common.s
@@ -422,6 +422,66 @@ SetCaseyMale:
     textcolor BLUE
     return
 
+.global BadgeObedienceMessage
+BadgeObedienceMessage:
+    callasm CountBadges
+    compare LASTRESULT 0
+    if equal _call NoBadges
+    compare LASTRESULT 1
+    if equal _call OneBadge
+    compare LASTRESULT 2
+    if equal _call TwoBadges
+    compare LASTRESULT 3
+    if equal _call ThreeBadges
+    compare LASTRESULT 4
+    if equal _call FourBadges
+    compare LASTRESULT 5
+    if equal _call FiveBadges
+    compare LASTRESULT 6
+    if equal _call SixBadges
+    compare LASTRESULT 7
+    if equal _call SevenBadges
+    compare LASTRESULT 8
+    if equal _call EightBadges
+    msgbox gText_Common_BadgeObedience MSG_KEEPOPEN
+    return
+
+NoBadges:
+    buffernumber 0x0 15
+    return
+
+OneBadge:
+    buffernumber 0x0 25
+    return
+
+TwoBadges:
+    buffernumber 0x0 35
+    return
+
+ThreeBadges:
+    buffernumber 0x0 45
+    return
+
+FourBadges:
+    buffernumber 0x0 55
+    return
+
+FiveBadges:
+    buffernumber 0x0 65
+    return
+
+SixBadges:
+    buffernumber 0x0 75
+    return
+
+SevenBadges:
+    buffernumber 0x0 85
+    return
+
+EightBadges:
+    buffernumber 0x0 100
+    return
+
 .global End
 End:
     release

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_gym.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_gym.s
@@ -162,11 +162,11 @@ LeaderChance_4Badges:
 
 EventScript_DaimynCityGym_LeaderChance_Defeated:
     msgbox gText_DaimynCityGym_LeaderChance_BadgeAwarded MSG_NORMAL
+    setflag 0x823 @ Daimyn gym badge
     fanfare 0x13D @ Gym victory
     msgbox gText_DaimynCityGym_BadgeReceived MSG_NORMAL
     call BadgeObedienceMessage
     waitfanfare
-    setflag 0x823 @ Daimyn gym badge
     settrainerflag 0x93 @ Jacob cannot be battled now
     settrainerflag 0x94 @ Kanesha cannot be battled now
     settrainerflag 0x95 @ Emilie cannot be battled now

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_gym.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_gym.s
@@ -163,7 +163,8 @@ LeaderChance_4Badges:
 EventScript_DaimynCityGym_LeaderChance_Defeated:
     msgbox gText_DaimynCityGym_LeaderChance_BadgeAwarded MSG_NORMAL
     fanfare 0x13D @ Gym victory
-    msgbox gText_DaimynCityGym_BadgeReceived MSG_KEEPOPEN
+    msgbox gText_DaimynCityGym_BadgeReceived MSG_NORMAL
+    call BadgeObedienceMessage
     waitfanfare
     setflag 0x823 @ Daimyn gym badge
     settrainerflag 0x93 @ Jacob cannot be battled now

--- a/assembly/overworld_scripts/ferrox_village/ferrox_gym.s
+++ b/assembly/overworld_scripts/ferrox_village/ferrox_gym.s
@@ -74,7 +74,8 @@ EventScript_FerroxGym_LeaderStella:
 EventScript_FerroxGym_LeaderStella_Defeated:
     msgbox gText_FerroxGym_LeaderStella_BadgeAwarded MSG_NORMAL
     fanfare 0x13D @ Gym victory
-    msgbox gText_FerroxGym_BadgeReceived MSG_KEEPOPEN
+    msgbox gText_FerroxGym_BadgeReceived MSG_NORMAL
+    call BadgeObedienceMessage
     waitfanfare
     setflag 0x821 @ Ferrox gym badge
     settrainerflag 0x3C @ Lorena cannot be battled now

--- a/assembly/overworld_scripts/ferrox_village/ferrox_gym.s
+++ b/assembly/overworld_scripts/ferrox_village/ferrox_gym.s
@@ -73,11 +73,11 @@ EventScript_FerroxGym_LeaderStella:
 
 EventScript_FerroxGym_LeaderStella_Defeated:
     msgbox gText_FerroxGym_LeaderStella_BadgeAwarded MSG_NORMAL
+    setflag 0x821 @ Ferrox gym badge
     fanfare 0x13D @ Gym victory
     msgbox gText_FerroxGym_BadgeReceived MSG_NORMAL
     call BadgeObedienceMessage
     waitfanfare
-    setflag 0x821 @ Ferrox gym badge
     settrainerflag 0x3C @ Lorena cannot be battled now
     settrainerflag 0x3D @ Lona cannot be battled now
     settrainerflag 0x3E @ Chet cannot be battled now

--- a/assembly/overworld_scripts/heleo_city/heleo_city_gym.s
+++ b/assembly/overworld_scripts/heleo_city/heleo_city_gym.s
@@ -142,7 +142,8 @@ LeaderRaine_4Badges:
 EventScript_HeleoGym_LeaderRaine_Defeated:
     msgbox gText_HeleoGym_LeaderRaine_BadgeAwarded MSG_NORMAL
     fanfare 0x13D @ Gym victory
-    msgbox gText_HeleoGym_BadgeReceived MSG_KEEPOPEN
+    msgbox gText_HeleoGym_BadgeReceived MSG_NORMAL
+    call BadgeObedienceMessage
     waitfanfare
     setflag 0x822 @ Heleo gym badge
     settrainerflag 0x65 @ Tessa cannot be battled now

--- a/assembly/overworld_scripts/heleo_city/heleo_city_gym.s
+++ b/assembly/overworld_scripts/heleo_city/heleo_city_gym.s
@@ -141,11 +141,11 @@ LeaderRaine_4Badges:
 
 EventScript_HeleoGym_LeaderRaine_Defeated:
     msgbox gText_HeleoGym_LeaderRaine_BadgeAwarded MSG_NORMAL
+    setflag 0x822 @ Heleo gym badge
     fanfare 0x13D @ Gym victory
     msgbox gText_HeleoGym_BadgeReceived MSG_NORMAL
     call BadgeObedienceMessage
     waitfanfare
-    setflag 0x822 @ Heleo gym badge
     settrainerflag 0x65 @ Tessa cannot be battled now
     settrainerflag 0x66 @ Byron cannot be battled now
     settrainerflag 0x67 @ Danette cannot be battled now

--- a/assembly/overworld_scripts/laplaz_town/laplaz_gym.s
+++ b/assembly/overworld_scripts/laplaz_town/laplaz_gym.s
@@ -208,12 +208,12 @@ FemaleCaseyBattle:
 
 EventScript_LaplazGym_LeaderCasey_Defeated:
     msgbox gText_LaplazGym_LeaderCasey_BadgeAwarded MSG_NORMAL
+    setflag 0x824 @ Laplaz gym badge
     fanfare 0x13D @ Gym victory
     textcolor BLACK
     msgbox gText_LaplazGym_BadgeReceived MSG_NORMAL
     call BadgeObedienceMessage
     waitfanfare
-    setflag 0x824 @ Laplaz gym badge
     settrainerflag 0xE3 @ Jeremiah cannot be battled now
     settrainerflag 0xE4 @ Exie cannot be battled now
     settrainerflag 0xE5 @ Virginia cannot be battled now

--- a/assembly/overworld_scripts/laplaz_town/laplaz_gym.s
+++ b/assembly/overworld_scripts/laplaz_town/laplaz_gym.s
@@ -210,7 +210,8 @@ EventScript_LaplazGym_LeaderCasey_Defeated:
     msgbox gText_LaplazGym_LeaderCasey_BadgeAwarded MSG_NORMAL
     fanfare 0x13D @ Gym victory
     textcolor BLACK
-    msgbox gText_LaplazGym_BadgeReceived MSG_KEEPOPEN
+    msgbox gText_LaplazGym_BadgeReceived MSG_NORMAL
+    call BadgeObedienceMessage
     waitfanfare
     setflag 0x824 @ Laplaz gym badge
     settrainerflag 0xE3 @ Jeremiah cannot be battled now

--- a/assembly/overworld_scripts/rhodanzi_city/rhodanzi_gym.s
+++ b/assembly/overworld_scripts/rhodanzi_city/rhodanzi_gym.s
@@ -59,11 +59,11 @@ EventScript_RhodanziGym_Leader_Terrence:
 
 EventScript_RhodanziGym_Leader_TerrenceDefeated:
     msgbox gText_RhodanziGym_Leader_Terrence_BadgeAwarded MSG_NORMAL
+    setflag 0x820 @ Rhodanzi gym badge
     fanfare 0x13D @ Gym victory
     msgbox gText_RhodanziGym_BadgeReceived MSG_NORMAL
     call BadgeObedienceMessage
     waitfanfare
-    setflag 0x820 @ Rhodanzi gym badge
     setvar 0x4097 0x1 @ Disable Team Pluto tile event  
     settrainerflag 0xC @ Alonso cannot be battled now
     settrainerflag 0xD @ Brandon cannot be battled now

--- a/assembly/overworld_scripts/rhodanzi_city/rhodanzi_gym.s
+++ b/assembly/overworld_scripts/rhodanzi_city/rhodanzi_gym.s
@@ -60,7 +60,8 @@ EventScript_RhodanziGym_Leader_Terrence:
 EventScript_RhodanziGym_Leader_TerrenceDefeated:
     msgbox gText_RhodanziGym_Leader_Terrence_BadgeAwarded MSG_NORMAL
     fanfare 0x13D @ Gym victory
-    msgbox gText_RhodanziGym_BadgeReceived MSG_KEEPOPEN
+    msgbox gText_RhodanziGym_BadgeReceived MSG_NORMAL
+    call BadgeObedienceMessage
     waitfanfare
     setflag 0x820 @ Rhodanzi gym badge
     setvar 0x4097 0x1 @ Disable Team Pluto tile event  

--- a/strings/scripts/bruccie_village/bruccie_village_gym.string
+++ b/strings/scripts/bruccie_village/bruccie_village_gym.string
@@ -65,7 +65,7 @@ I'm not a sore loser.\pCongratulations! That was a\nfantastic battle.
 [PLAYER] received the Talent Badge!
 
 #org @gText_BruccieVillageGym_LeaderAbby_BadgeDescription
-[RED]That badge is proof of your victory\ntoday.\pLook upon it with pride. Very few\ntrainers can earn it.\pYour Pok\emon will take note of this\nbadge as well.\pAs a result, all Pok\emon up to level\n75 will obey your commands without\lfail.\pThat's not all.\pWith this badge, your Pok\emon will\nbe able to surf outside of battle,\lso long as you have the required\lHM.
+[RED]That badge is proof of your victory\ntoday.\pLook upon it with pride. Very few\ntrainers can earn it.\pYour Pok\emon will take note of this\nbadge as well.\pWith this badge, your Pok\emon will\nbe able to surf outside of battle,\lso long as you have the required\lHM.
 
 #org @gText_BruccieVillageGym_LeaderAbby_TMReceived
 [RED]I'd like you to have this as well.\nThis TM teaches Role Play.\pUse this move to prevent your\nopponents' abilities from getting\lthe better of you.

--- a/strings/scripts/common/common.string
+++ b/strings/scripts/common/common.string
@@ -150,3 +150,6 @@ S+
 
 #org @gText_Common_FoongusOrAmoongussTrap
 The item was actually a Pok\emon!\nThe startled Pok\emon attacked!
+
+#org @gText_Common_BadgeObedience
+Pok\emon up to level [BUFFER1] will now\nobey you without fail.

--- a/strings/scripts/daimyn_city/daimyn_city_gym.string
+++ b/strings/scripts/daimyn_city/daimyn_city_gym.string
@@ -290,7 +290,7 @@ That's the game! A real gambler\nknows when to fold with dignity.
 [PLAYER] received the Roundabout\nBadge!
 
 #org @gText_DaimynCityGym_LeaderChance_BadgeDescription
-[BLUE]That badge is proof of your skills.\pWith it, all Pok\emon up to level 55\nwill obey you.\pAs well, you'll be able to use Fly\noutside of battle now.
+[BLUE]That badge is proof of your skills.\pIt will also allow you to use the\nmove Fly outside of battle.
 
 #org @gText_DaimynCityGym_LeaderChance_TMReceived
 [BLUE]Please take these TMs as well.\pI'm sure you'll be able to use them\nto keep your opponents on their\ltoes.

--- a/strings/scripts/ferrox_village/ferrox_gym.string
+++ b/strings/scripts/ferrox_village/ferrox_gym.string
@@ -38,7 +38,7 @@ Oh my[.] I didn't expect you to battle\nso fiercely.
 [PLAYER] received TM06 from Stella!
 
 #org @gText_FerroxGym_LeaderStella_BadgeDescription
-[RED]This badge represents what you've\naccomplished today. Your Pok\emon\lwill surely have taken note of it\las well.\pSimply by holding this badge, all\nPok\emon up to level 35 will obey\lyour commands.\pYou'll also be able to use the move\nCut outside of battle.
+[RED]This badge represents what you've\naccomplished today. Your Pok\emon\lwill surely have taken note of it\las well.\pYou'll also be able to use the move\nCut outside of battle.
 
 #org @gText_FerroxGym_LeaderStella_TMReceived
 [RED]Please also take this TM, which\nis a favorite of mine.\pThis TM teaches your Pok\emon the\nmove Toxic. It causes your foe to\ltake additional poison damage for\leach consecutive turn in battle.\pUsing it strategically will surely\nlead you to more victories.

--- a/strings/scripts/heleo_city/heleo_city_gym.string
+++ b/strings/scripts/heleo_city/heleo_city_gym.string
@@ -56,7 +56,7 @@ That battle was quite entertaining,\nindeed! You have my gratitude.
 [PLAYER] received the Stormcloud\nBadge!
 
 #org @gText_HeleoGym_LeaderRaine_BadgeDescription
-[RED]Take this badge with pride.\pPossessing it will allow all Pok\emon\nup to at least level 45 to obey\lyou.\pIt will also allow your Pok\emon to\nuse Rock Smash outside of battle.
+[RED]Take this badge with pride.\pIt will allow your Pok\emon to\nuse Rock Smash outside of battle.
 
 #org @gText_HeleoGym_LeaderRaine_TMReceived
 [RED]As proof of your accomplishment\ntoday, you may also take these\lTMs.\pThese TMs will teach your Pok\emon\nHail, Sunny Day, Rain Dance, or\lSandstorm.\pI would encourage you to apply what\nyou've learned in this gym to make\lthe most of these TMs.

--- a/strings/scripts/laplaz_town/laplaz_gym.string
+++ b/strings/scripts/laplaz_town/laplaz_gym.string
@@ -113,7 +113,7 @@ What a wonderful battle[.]\n[PLAYER], thank you.\pI'm more convinced than ever t
 [PLAYER] received the Tactician\nBadge!
 
 #org @gText_LaplazGym_LeaderCasey_BadgeDescription
-That badge is proof of your\nachievement today.\pIt's also a symbol of what the gym\nchallenge means to so many.\p[PLAYER], with this badge, Pok\emon up\nto level 65 will obey you.
+That badge is proof of your\nachievement today.\pIt's also a symbol of what the gym\nchallenge means to so many.
 
 #org @gText_LaplazGym_LeaderCasey_TMReceived
 Please take this TM as well.\pIt contains Swords Dance, and it's\na favorite of mine.

--- a/strings/scripts/rhodanzi_city/rhodanzi_gym.string
+++ b/strings/scripts/rhodanzi_city/rhodanzi_gym.string
@@ -53,7 +53,7 @@ You battled well, [PLAYER].\pYour gym challenge will take you\nto Ferrox Village
 [PLAYER] received TM05 from Terrence!
 
 #org @gText_RhodanziGym_Leader_Terrence_BadgeDescription
-[BLUE]This badge is proof of your\nvictory over me, and your\lcapabilities as a trainer.\lAll Pok\emon up to level 25 will\lnow obey you without fail.
+[BLUE]This badge is proof of your\nvictory over me, and your\lcapabilities as a trainer.
 
 #org @gText_RhodanziGym_Leader_Terrence_TMReceived
 [BLUE]I will also give you TM05, which\ncontains Terrain Pulse. It can be\ltaught to your Pok\emon as many\ltimes as you'd like.\pI'd suggest visiting the terrain tutor\nat Rhodanzi Trainer school to make\lthe most of it.


### PR DESCRIPTION
Updates the gym leader scripts to calculate the number of badges held and communicate the new obedience level cap accordingly.

This is to support players that may do gyms 3-5 out of order, which previously would cause gym leaders to report inaccurate levels.  Ex. if Laplaz (gym 5) was done 3rd, the raised level cap would actually be 45 and not 65.