### PR TITLE
Expand town map to include unique names for Calicin Bay and Pluto HQ

### DIFF
--- a/include/constants/region_map_sections.h
+++ b/include/constants/region_map_sections.h
@@ -60,8 +60,8 @@ u8 __attribute__((long_call)) GetCurrentRegionMapSectionId(void);
 #define MAPSEC_ASCENSION_TOWER              0x8C
 #define MAPSEC_ROUTE_12_EAST                0x8D
 #define MAPSEC_DAIMYN_FACTORY               0x8E
-#define MAPSEC_ONE_ISLAND                   0x8F
-#define MAPSEC_TWO_ISLAND                   0x90
+#define MAPSEC_CALICIN_BAY                  0x8F
+#define MAPSEC_PLUTO_HQ                     0x90
 #define MAPSEC_THREE_ISLAND                 0x91
 #define MAPSEC_FOUR_ISLAND                  0x92
 #define MAPSEC_FIVE_ISLAND                  0x93

--- a/include/constants/region_map_sections.h
+++ b/include/constants/region_map_sections.h
@@ -67,7 +67,7 @@ u8 __attribute__((long_call)) GetCurrentRegionMapSectionId(void);
 #define MAPSEC_FIVE_ISLAND                  0x93
 #define MAPSEC_SEVEN_ISLAND                 0x94
 #define MAPSEC_SIX_ISLAND                   0x95
-#define MAPSEC_KINDLE_ROAD                  0x96
+#define MAPSEC_SCALDING_SPA                 0x96
 #define MAPSEC_TREASURE_BEACH               0x97
 #define MAPSEC_CAPE_BRINK                   0x98
 #define MAPSEC_BOND_BRIDGE                  0x99

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -2099,7 +2099,7 @@ bool8 IsCurrentAreaHotCave(void)
 {
 	#ifdef NEW_BATTLE_BACKGROUNDS
 		u8 mapSec = GetCurrentRegionMapSectionId();
-		return mapSec == MAPSEC_ROUTE_12_EAST; // Scalding Spa is here
+		return mapSec == MAPSEC_SCALDING_SPA;
 	#else
 		return FALSE;
 	#endif

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -2079,7 +2079,7 @@ bool8 IsCurrentAreaWinter(void)
 {
 	#ifdef NEW_BATTLE_BACKGROUNDS
 		u8 mapSec = GetCurrentRegionMapSectionId();
-		return mapSec == MAPSEC_ROUTE_12_WEST || mapSec == MAPSEC_BRUCCIE_VILLAGE;
+		return mapSec == MAPSEC_ROUTE_12_WEST || mapSec == MAPSEC_BRUCCIE_VILLAGE || mapSec == MAPSEC_CALICIN_BAY;
 	#else
 		return FALSE;
 	#endif


### PR DESCRIPTION
Expands the list of map names attributed to the main town map (Kulure) to allow Calicin Bay and Pluto HQ to have their own map names on entry, on the town map, and on save files.