### PR TITLE
Change how the TM case handles learned moves

### DIFF
--- a/src/tm_case.c
+++ b/src/tm_case.c
@@ -148,6 +148,13 @@ void CreateTMCaseSprite(void)
 	}
 }
 
+void StopSpriteAnimation(struct Sprite* sprite)
+{
+	SetPartyHPBarSprite(sprite, 0); //Stop moving and reload original frame
+	sprite->callback(sprite); //Update frame
+	sprite->callback = SpriteCallbackDummy; //Stop animating old mon icon
+}
+
 void ChangeMonIconPalsInTMCase(u16 itemId)
 {
 	u32 i;
@@ -163,13 +170,16 @@ void ChangeMonIconPalsInTMCase(u16 itemId)
 			{
                 sprite->oam.objMode = ST_OAM_OBJ_NORMAL;
 				sprite->callback = SpriteCB_PokeIcon;
+
+				if (canLearn == 2) // Already knows move, have colored but stop animation
+				{
+					StopSpriteAnimation(sprite);
+				}
 			}
 			else
 			{
                 sprite->oam.objMode = ST_OAM_OBJ_BLEND;
-                SetPartyHPBarSprite(sprite, 0); //Stop moving and reload original frame
-				sprite->callback(sprite); //Update frame
-				sprite->callback = SpriteCallbackDummy; //Stop animating old mon icon
+                StopSpriteAnimation(sprite);
 			}
 		}
 	}


### PR DESCRIPTION
Update the TM Case to have better distinctions between a Pokemon's relation to a move:

- Greyscale, not animated:  Pokemon cannot learn the move
- Colored, not animated: Pokemon knows the move already (New!)
- Colored, animated: Pokemon can learn the move

![TM Case improvement](https://github.com/assassinsgreed/Complete-Fire-Red-Upgrade/assets/2691249/88987e90-1bfe-4995-9464-d30afb419dbc)
