### PR TITLE
Improve illumination on the mega trigger

### DIFF
--- a/src/battle_indicators.c
+++ b/src/battle_indicators.c
@@ -459,8 +459,8 @@ static struct SpriteTemplate sTypeIconSpriteTemplate2 =
 static const u16 sIgnoredTriggerColours[] =
 {
 	RGB(18, 14, 23), //Pink
-	RGB(16, 11, 23), //Purple
-	RGB(11, 4, 15), //Purple
+	// RGB(16, 11, 23), //Purple
+	// RGB(11, 4, 15), //Purple
 	RGB(30, 23, 10), //Gold
 	RGB(26, 18, 2), //Gold
 	RGB(31, 31, 31), //White


### PR DESCRIPTION
Do not exclude the purples of the mega indicator, so they are illuminated with the others when activating mega evolution.  This palette adjustment will also apply to other triggers (Z Moves, primal reversion, ultra burst)

Deactivated:
![image](https://github.com/assassinsgreed/Complete-Fire-Red-Upgrade/assets/2691249/8a689081-d01a-478f-8033-1581414298b2)


Old Activated:
![image](https://github.com/assassinsgreed/Complete-Fire-Red-Upgrade/assets/2691249/15e22f00-40eb-4680-8d88-964d5f9db6e5)


New Activated:
![image](https://github.com/assassinsgreed/Complete-Fire-Red-Upgrade/assets/2691249/f1548ea4-76ed-4f48-8d31-d53d4c7d7ea4)
