### PR TITLE
Fix minior colors by only sending out shielded minior

### DIFF
--- a/automation/WildEncounters.json
+++ b/automation/WildEncounters.json
@@ -798,9 +798,9 @@
                 "pokemon": [
                     { "low": 40, "high": 50, "species": "SPECIES_SHUCKLE" },
                     { "low": 40, "high": 50, "species": "SPECIES_CARBINK" },
-                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_INDIGO" },
-                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_ORANGE" },
-                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_GREEN" }
+                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_SHIELD" }
                 ]
             }
         },
@@ -829,9 +829,9 @@
                 "pokemon": [
                     { "low": 40, "high": 50, "species": "SPECIES_SHUCKLE" },
                     { "low": 40, "high": 50, "species": "SPECIES_CARBINK" },
-                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_INDIGO" },
-                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_ORANGE" },
-                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_GREEN" }
+                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 40, "high": 50, "species": "SPECIES_MINIOR_SHIELD" }
                 ]
             }
         },
@@ -1758,11 +1758,11 @@
             "rocks": {
                 "rate": 150,
                 "pokemon": [
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_RED" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_ORANGE" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_YELLOW" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_GREEN" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_BLUE" }
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" }
                 ]
             }
         },
@@ -1789,11 +1789,11 @@
             "rocks": {
                 "rate": 150,
                 "pokemon": [
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_INDIGO" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_VIOLET" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_YELLOW" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_GREEN" },
-                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_BLUE" }
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" },
+                    { "low": 35, "high": 40, "species": "SPECIES_MINIOR_SHIELD" }
                 ]
             }
         },

--- a/src/Tables/trainer_tables.c
+++ b/src/Tables/trainer_tables.c
@@ -2192,7 +2192,7 @@ const struct TrainerMonNoItemDefaultMoves sParty_Route8_NinjaBoyZeke[] = {
 
 const struct TrainerMonNoItemDefaultMoves sParty_Route8_SuperNerdSaul[] = {
     { .lvl = 24, .species = SPECIES_DRILBUR },
-    { .lvl = 24, .species = SPECIES_MINIOR_INDIGO },
+    { .lvl = 24, .species = SPECIES_MINIOR_SHIELD },
     { .lvl = 25, .species = SPECIES_CRABRAWLER }
 };
 


### PR DESCRIPTION
Fix minior color bugs by only sending out shielded minior.  The form change is based on the pokemon's personality, so we shouldn't use a specific color because it's very likely it won't match the personality assigned color