### PR TITLE
Fix some issues with Ena's event and references to Carnelidge Volcano

### DIFF
--- a/assembly/overworld_scripts/routes/route_11.s
+++ b/assembly/overworld_scripts/routes/route_11.s
@@ -25,6 +25,8 @@ MapScript_Route11South:
 MapEntryScript_SetPartnerPositions:
     compare PlutoEncounterVar 0x1 @ Exit if story events haven't kicked off
     if lessthan _goto End
+    checkflag 0x26F @ Spoke to Ena
+    if SET _call SetEnaLocationPostBadge7
     movesprite2 Rival 0x1C 0x2E @ Update position of Rival permanently
     movesprite2 Alistair 0x1D 0x2E @ Update position of Alistair permanently
     compare PlutoEncounterVar 0x4 @ Exit if player has beaten Team Pluto (i.e. no more partnering)
@@ -48,6 +50,11 @@ MapResumeScript_SetupPartnerBattles:
     if equal _call SetRivalBacksprite
     if greaterthan _call SetAlistairBacksprite    
     end
+
+SetEnaLocationPostBadge7:
+    movesprite 29 0x2A 0x36
+    movesprite2 29 0x2A 0x36
+    return
 
 SetRivalBacksprite:
     setvar 0x5012 0x6
@@ -609,7 +616,7 @@ HandleEnaEvent:
     msgbox gText_Route11South_EnaAsksForHelp MSG_NORMAL
     applymovement 29 m_LookDown
     fadedefaultbgm
-    movesprite2 29 0x2A 0x36
+    call SetEnaLocationPostBadge7
     setflag 0x26F @ Spoke to Ena
     goto EventScript_Route11South_EnaPostGym7
 

--- a/strings/scripts/routes/route_11.string
+++ b/strings/scripts/routes/route_11.string
@@ -557,4 +557,4 @@ Did you know? These ponds were dug\nout by the citizens of Laplaz Town.\pThere a
 [RED]But[.] I don't want to do that.\nWe don't want to do that.\pLook, I won't beat around the bush.\pYou made life really hard for Clancy\nand I for a long, long time.\pBut[.] You're also the only one who\nwas willing to give us a real\lchance to fix our mistakes.\pSomething tells me the whole\nsituation stinks. It can't be real.\pAnd, something tells me you won't let\nthis guy get away with whatever\lhe's really scheming[.]\pGranting someone's dreams? And\nasking almost nothing in return?\pThat's the kind of nonsense Team\nPluto would've come up with.\pSo, please[.]
 
 #org @gText_Route11South_EnaChat
-[RED]Could you check into whatever is\nhappening at Mount Carnelidge?\pYou're the only person I can ask[.]\pAnd[.] Thank you in advance. I'll be\ngoing back to Uteya Village soon.
+[RED]Could you check into whatever is\nhappening at Carnelidge Volcano?\pYou're the only person I can ask[.]\pAnd[.] Thank you in advance. I'll be\ngoing back to Uteya Village soon.

--- a/strings/scripts/routes/route_13.string
+++ b/strings/scripts/routes/route_13.string
@@ -1,5 +1,5 @@
 #org @gText_Route13_RestHouse
-Mount Carnelidge Rest House\pRest up and restock before pushing\nfor the mountain peak!
+Carnelidge Volcano Rest House\pRest up and restock before pushing\nfor the mountain peak!
 
 #org @gText_Route13_TrainerTips
 Trainer Tips!\pCertain locations can be returned to\nwith Fly, even if they don't have\la Pok\emon Center.
@@ -101,7 +101,7 @@ Ah, much better! It's important to be\nwell rested before climbing Mount\lCarnel
 Wow, there are so many names in this\nguest book!\lI had no idea so many people came\lout this way.
 
 #org @gText_Route13_RestHouse_RestHouseRep
-Hello, trainer! Mount Carnelidge is\nquite dangerous.\pWe've set up this Rest House to give\naspiring mountain climbers the\lopportunity to rest and refresh\lbefore tackling the mountain.\pNow that you've visited us, you'll\nbe able to return here by having\lyour Pok\emon use Fly. Provided you\lhave the necessary badge and HM,\lof course!\pPlease feel free to use any of\nthe amenities you find at the rest\lhouse!
+Hello, trainer! Carnelidge Volcano is\nquite dangerous.\pWe've set up this Rest House to give\naspiring mountain climbers the\lopportunity to rest and refresh\lbefore tackling the mountain.\pNow that you've visited us, you'll\nbe able to return here by having\lyour Pok\emon use Fly. Provided you\lhave the necessary badge and HM,\lof course!\pPlease feel free to use any of\nthe amenities you find at the rest\lhouse!
 
 #org @gText_Route13_GruntLeft
 I could've sworn this was the\nmeeting spot[.]\pYou don't think they left without us,\ndo you?

--- a/strings/scripts/routes/route_21.string
+++ b/strings/scripts/routes/route_21.string
@@ -23,7 +23,7 @@ Tally ho! You think you're strong\nenough to challenge Victory Road?
 Ho ho! You just might be!
 
 #org @gText_Route21_HikerRicardo_Chat
-Most hikers choose Mount Carnelidge\nas their end goal.\pThose that battle come to Victory\nRoad instead!
+Most hikers choose Carnelidge\nVolcano as their end goal.\pThose that battle come to Victory\nRoad instead!
 
 #org @gText_Route21_DragonTamerTanner_Intro
 I have honed the Pok\emon I inherited\nfrom my clan[.]

--- a/strings/scripts/towns/daimyn_city.string
+++ b/strings/scripts/towns/daimyn_city.string
@@ -1051,7 +1051,7 @@ I'm so tired[.] Why does this mall\nhave to be so big?
 I'm waiting for my friends to get\nhere so we can go shopping!
 
 #org @gText_DaimynCityMall_EvolutionStonesSeller
-[BLACK]I offer rare stones excavated from\nMount Carnelidge. Want to see?
+[BLACK]I offer rare stones excavated from\nCarnelidge Volcano. Want to see?
 
 #org @gText_DaimynCityMall_HeldItemSeller
 [BLACK]My items help your Pok\emon in\nbattle. You'll need these to win!

--- a/strings/scripts/towns/ferrox_village.string
+++ b/strings/scripts/towns/ferrox_village.string
@@ -34,7 +34,7 @@ Some Pok\eMarts sell items produced\nlocally. It's always worth checking\lin whe
 All of the berries sold here were\ngrown on good ol' Ferrox soil.\pThey taste good in soup, but you\nmight also find them useful if\lyou're thinking of challenging the\lFerrox Gym.
 
 #org @gText_FerroxFacilities_Mart_FerroxHikers
-Ferrox Village is often the last stop\nfor hikers making their way to\lMount Carnelidge.\pHave you been? There's a path\nthrough Torma Cave that leads\lthere. You might find some strong\lPok\emon there.
+Ferrox Village is often the last stop\nfor hikers making their way to\lCarnelidge Volcano.\pHave you been there before? There's\na path through Torma Cave that\lleads there.\pYou might find some strong Pok\emon\nthere.
 
 #org @gText_FerroxFacilities_Mart_StellaSibling
 I heard a rumour that Stella and\nIris are related.\pStella is really quiet, but Iris is\nso full of life! Could they really\lbe siblings?


### PR DESCRIPTION
Fix some issues with Ena's event, and text that incorrectly refers to Carnelidge Volcano as Mount Carnelidge