### PR TITLE
Add support for braille strings

### DIFF
--- a/scripts/string.py
+++ b/scripts/string.py
@@ -157,6 +157,37 @@ SpecialBuffers = {
     "EMOJI_BIGANGER": ["F9", "FE"],
 }
 
+BrailleMapping = {
+    'A': 0x01,
+    'B': 0x05,
+    'C': 0x03,
+    'D': 0x0B,
+    'E': 0x09,
+    'F': 0x07,
+    'G': 0x0F,
+    'H': 0x0D,
+    'I': 0x06,
+    'J': 0x0E,
+    'K': 0x11,
+    'L': 0x15,
+    'M': 0x13,
+    'N': 0x1B,
+    'O': 0x19,
+    'P': 0x17,
+    'Q': 0x1F,
+    'R': 0x1D,
+    'S': 0x16,
+    'T': 0x1E,
+    'U': 0x31,
+    'V': 0x35,
+    'W': 0x2E,
+    'X': 0x33,
+    'Y': 0x3B,
+    'Z': 0x39,
+    ' ': 0x00,
+    ',': 0x04,
+    '.': 0x2C,
+}
 
 def StringFileConverter(fileName: str):
     stringToWrite = ".thumb\n.text\n.align 2\n\n"
@@ -218,6 +249,7 @@ def ProcessString(string: str, lineNum: int, maxLength=0, fillWithFF=False) -> s
     stringToWrite = ".byte "
     buffer = False
     escapeChar = False
+    braille = False
     bufferChars = ""
     strLen = 0
 
@@ -241,6 +273,8 @@ def ProcessString(string: str, lineNum: int, maxLength=0, fillWithFF=False) -> s
                         stringToWrite += ("0x" + bufferChar + ", ")
                         strLen += 1
 
+                elif bufferChars == "BRAILLE":
+                    braille = True
                 elif len(bufferChars) > 2:  # Unrecognized buffer
                     print('Warning: The string buffer "' + bufferChars + '" is not recognized!')
                     stringToWrite += "0x0, "  # Place whitespace where the buffer should have gone
@@ -265,7 +299,10 @@ def ProcessString(string: str, lineNum: int, maxLength=0, fillWithFF=False) -> s
 
         else:
             try:
-                stringToWrite += hex(charMap[char]) + ", "
+                if braille:
+                    stringToWrite += hex(BrailleMapping[char]) + ", "
+                else: 
+                    stringToWrite += hex(charMap[char]) + ", "
                 strLen += 1
 
             except KeyError:

--- a/xse_commands.s
+++ b/xse_commands.s
@@ -1145,6 +1145,8 @@ map \map
 .endm
 
 @ Displays the string at pointer as braille text in a standard message box. The string must be formatted to use braille characters.
+@ This is being managed by the [BRAILLE] buffer characters in string.py.
+@ Braille strings must be written in all uppercase like [BRAILLE]MY MESSAGE
 .macro braillemessage text:req
 .byte 0x78
 .4byte \text
@@ -1926,6 +1928,13 @@ map \map
 	getbraillestringwidth \text
 	call EventScript_BrailleCursorWaitButton
 .endm*/
+
+.macro braillemsgbox text:req
+	braillemessage \text
+	getbraillestringwidth \text
+	waitkeypress
+    closeonkeypress
+.endm
 
 .macro multichoiceoption text:req num:req
 	setvar 0x8006 \num


### PR DESCRIPTION
Can be used by writing a string like:

```s
#org @gText_Braille
[BRAILLE]HELLO
```

and using it in an event like

```s
braillemsgbox gText_Braille
```

This uses a string replacement logic in `string.py` to replace all alphabetic characters with the correct braille hex values. The `braillemsgbox` command has convenience functionality to wait for the box to display and dismiss upon keypress