### PR TITLE
Fix double battles with unpaired trainers throughout the game

### DIFF
--- a/assembly/overworld_scripts/dungeons/peradon_forest.s
+++ b/assembly/overworld_scripts/dungeons/peradon_forest.s
@@ -141,7 +141,7 @@ EventScript_PeradonForest_BugCatcherLyle:
     compare PLAYERFACING LEFT
     if equal _call LyleAndEricaLookRight
     @ Perform a double battle with Lyle & Erica's teams (237 and 238), referencing their overworld NPC IDs (17 and 18), with their respective intro/defeat/chat text
-    trainerbattle11 0x0 237 238 17 18 0x0 gText_PeradonForest_BugCatcherLyle_Intro gText_PeradonForest_BeautyErica_Intro gText_PeradonForest_BugCatcherLyle_Defeat gText_PeradonForest_BeautyErica_Defeat gText_PeradonForest_BugCatcherLyle_Chat gText_PeradonForest_BeautyErica_Chat
+    trainerbattle11 0x0 237 238 17 18 0x0 gText_PeradonForest_BugCatcherLyle_Intro gText_PeradonForest_BeautyErica_Intro gText_PeradonForest_BugCatcherLyle_Defeat gText_PeradonForest_BeautyErica_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Female
     msgbox gText_PeradonForest_BugCatcherLyle_Chat MSG_NORMAL
     end
 
@@ -150,7 +150,7 @@ EventScript_PeradonForest_BeautyErica:
     compare PLAYERFACING RIGHT
     if equal _call LyleAndEricaLookLeft
     @ Perform a double battle with Lyle & Erica's teams (237 and 238), referencing their overworld NPC IDs (17 and 18), with their respective intro/defeat/chat text
-    trainerbattle11 0x0 237 238 17 18 0x0 gText_PeradonForest_BugCatcherLyle_Intro gText_PeradonForest_BeautyErica_Intro gText_PeradonForest_BugCatcherLyle_Defeat gText_PeradonForest_BeautyErica_Defeat gText_PeradonForest_BugCatcherLyle_Chat gText_PeradonForest_BeautyErica_Chat
+    trainerbattle11 0x0 237 238 17 18 0x0 gText_PeradonForest_BugCatcherLyle_Intro gText_PeradonForest_BeautyErica_Intro gText_PeradonForest_BugCatcherLyle_Defeat gText_PeradonForest_BeautyErica_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Female
     msgbox gText_PeradonForest_BeautyErica_Chat MSG_NORMAL
     end
 

--- a/assembly/overworld_scripts/dungeons/scalding_spa.s
+++ b/assembly/overworld_scripts/dungeons/scalding_spa.s
@@ -255,7 +255,7 @@ EventScript_ScaldingSpa_HikerEugene:
     // Double battle with Stephen
     compare PLAYERFACING LEFT
     if equal _call EugeneAndStephenLookRight
-    trainerbattle11 0x0 251 252 14 15 0x0 gtext_ScaldingSpa_HikerEugene_Intro gtext_ScaldingSpa_SupernerdStephen_Intro gtext_ScaldingSpa_HikerEugene_Defeat gtext_ScaldingSpa_SupernerdStephen_Defeat gtext_ScaldingSpa_HikerEugene_Chat gtext_ScaldingSpa_SupernerdStephen_Chat
+    trainerbattle11 0x0 251 252 14 15 0x0 gtext_ScaldingSpa_HikerEugene_Intro gtext_ScaldingSpa_SupernerdStephen_Intro gtext_ScaldingSpa_HikerEugene_Defeat gtext_ScaldingSpa_SupernerdStephen_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Male
     msgbox gtext_ScaldingSpa_HikerEugene_Chat MSG_NORMAL
     end
 
@@ -264,7 +264,7 @@ EventScript_ScaldingSpa_SuperNerdStephen:
     // Double battle with Eugene
     compare PLAYERFACING RIGHT
     if equal _call EugeneAndStephenLookLeft
-    trainerbattle11 0x0 251 252 14 15 0x0 gtext_ScaldingSpa_HikerEugene_Intro gtext_ScaldingSpa_SupernerdStephen_Intro gtext_ScaldingSpa_HikerEugene_Defeat gtext_ScaldingSpa_SupernerdStephen_Defeat gtext_ScaldingSpa_HikerEugene_Chat gtext_ScaldingSpa_SupernerdStephen_Chat
+    trainerbattle11 0x0 251 252 14 15 0x0 gtext_ScaldingSpa_HikerEugene_Intro gtext_ScaldingSpa_SupernerdStephen_Intro gtext_ScaldingSpa_HikerEugene_Defeat gtext_ScaldingSpa_SupernerdStephen_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Male
     msgbox gtext_ScaldingSpa_SupernerdStephen_Chat MSG_NORMAL
     end
 

--- a/assembly/overworld_scripts/routes/route_19.s
+++ b/assembly/overworld_scripts/routes/route_19.s
@@ -36,7 +36,7 @@ EventScript_Route19_PokefanPhineas:
     // Double battle with Phoebe
     compare PLAYERFACING RIGHT
     if equal _call PhineasAndPhoebeLookLeft
-    trainerbattle11 0x0 363 364 5 6 0x0 gText_Route19_PokefanPhineas_Intro gText_Route19_PokefanPhoebe_Intro gText_Route19_PokefanPhineas_Defeat gText_Route19_PokefanPhoebe_Defeat gText_Route19_PokefanPhineas_Chat gText_Route19_PokefanPhoebe_Chat
+    trainerbattle11 0x0 363 364 5 6 0x0 gText_Route19_PokefanPhineas_Intro gText_Route19_PokefanPhoebe_Intro gText_Route19_PokefanPhineas_Defeat gText_Route19_PokefanPhoebe_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Female
     msgbox gText_Route19_PokefanPhineas_Chat MSG_NORMAL
     end
 
@@ -45,7 +45,7 @@ EventScript_Route19_PokefanPhoebe:
     // Double battle with Phineas
     compare PLAYERFACING LEFT
     if equal _call PhineasAndPhoebeLookRight
-    trainerbattle11 0x0 363 364 5 6 0x0 gText_Route19_PokefanPhineas_Intro gText_Route19_PokefanPhoebe_Intro gText_Route19_PokefanPhineas_Defeat gText_Route19_PokefanPhoebe_Defeat gText_Route19_PokefanPhineas_Chat gText_Route19_PokefanPhoebe_Chat
+    trainerbattle11 0x0 363 364 5 6 0x0 gText_Route19_PokefanPhineas_Intro gText_Route19_PokefanPhoebe_Intro gText_Route19_PokefanPhineas_Defeat gText_Route19_PokefanPhoebe_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Female
     msgbox gText_Route19_PokefanPhoebe_Chat MSG_NORMAL
     end
 

--- a/assembly/overworld_scripts/routes/route_5.s
+++ b/assembly/overworld_scripts/routes/route_5.s
@@ -65,16 +65,16 @@ EventScript_Route5_LadyJuliet:
     compare PLAYERFACING LEFT
     if equal _call JulietAndMarcusLookRight
     @ Perform a double battle with Juliet & Marcus' teams (0x47 and 0x48), referencing their overworld NPC IDs (0x10 and 0x11), with their respective intro/defeat/chat text
-    trainerbattle11 0x0 0x47 0x48 0x10 0x11 0x0 gText_Route5_LadyJuliet_Intro gText_Route5_GentlemanMarcus_Intro gText_Route5_LadyJuliet_Defeat gText_Route5_GentlemanMarcus_Defeat gText_Route5_LadyJuliet_Chat gText_Route5_GentlemanMarcus_Chat
+    trainerbattle11 0x0 0x47 0x48 0x10 0x11 0x0 gText_Route5_GentlemanMarcus_Intro gText_Route5_LadyJuliet_Intro gText_Route5_LadyJuliet_Defeat gText_Route5_GentlemanMarcus_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Female
     msgbox gText_Route5_LadyJuliet_Chat MSG_NORMAL
     end
-
+    
 .global EventScript_Route5_GentlemanMarcus
 EventScript_Route5_GentlemanMarcus:
     compare PLAYERFACING RIGHT
     if equal _call JulietAndMarcusLookLeft
     @ Perform a double battle with Juliet & Marcus' teams (0x47 and 0x48), referencing their overworld NPC IDs (0x10 and 0x11), with their respective intro/defeat/chat text
-    trainerbattle11 0x0 0x47 0x48 0x10 0x11 0x0 gText_Route5_LadyJuliet_Intro gText_Route5_GentlemanMarcus_Intro gText_Route5_LadyJuliet_Defeat gText_Route5_GentlemanMarcus_Defeat gText_Route5_LadyJuliet_Chat gText_Route5_GentlemanMarcus_Chat
+    trainerbattle11 0x0 0x47 0x48 0x10 0x11 0x0 gText_Route5_LadyJuliet_Intro gText_Route5_GentlemanMarcus_Intro gText_Route5_LadyJuliet_Defeat gText_Route5_GentlemanMarcus_Defeat gText_Common_CannotDoubleBattle_Male gText_Common_CannotDoubleBattle_Female
     msgbox gText_Route5_GentlemanMarcus_Chat MSG_NORMAL
     end
 


### PR DESCRIPTION
Fix double battles with trainers throughout the game:
- The correct text shows for the person before and after battle
- The correct text shows when the player doesn't have enough pokemon