### PR TITLE
Chore: Add locks before all player facing events

### DIFF
--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_facilities.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_facilities.s
@@ -266,6 +266,7 @@ EventScript_DaimynCityFacilities_Pokeball:
 
 .global EventScript_DaimynCityFacilities_ProfessorSakura
 EventScript_DaimynCityFacilities_ProfessorSakura:
+    lock
     checkflag 0x274 @ Permitted to go to ultra space
     if SET _goto SakuraAsksToGoToUltraSpace
     msgbox gText_DaimynCityFacilities_IRF_SakuraPreoccupied MSG_NORMAL

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_gym.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_gym.s
@@ -634,6 +634,7 @@ EventScript_DaimynCityGym_NPCWoman:
 
 .global EventScript_DaimynCityGym_NPCPsychic
 EventScript_DaimynCityGym_NPCPsychic:
+    lock
     msgbox gText_DaimynCityGym_NPCPsychic MSG_NORMAL
     faceplayer
     msgbox gText_DaimynCityGym_NPCPsychicFollowUp MSG_NORMAL

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_npc_houses.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_npc_houses.s
@@ -133,6 +133,7 @@ PlantAfterAlistair:
 
 .global EventScript_DaimynCity_MoveTutor
 EventScript_DaimynCity_MoveTutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
     buffernumber 0x0 0x8005 @ Take stored PokeChip count

--- a/assembly/overworld_scripts/daimyn_city/daimyn_city_overworld.s
+++ b/assembly/overworld_scripts/daimyn_city/daimyn_city_overworld.s
@@ -305,6 +305,7 @@ EventScript_DaimynCity_FindTM54FalseSwipe:
 
 .global EventScript_DaimynCity_RivalExhibitionBattle
 EventScript_DaimynCity_RivalExhibitionBattle:
+    lock
     faceplayer
     checkflag 0xE36 @ Rival exhbition battle already completed
     if SET _goto AlreadyCompletedRivalExhibitionBattleToday

--- a/assembly/overworld_scripts/dungeons/carnelidge_volcano.s
+++ b/assembly/overworld_scripts/dungeons/carnelidge_volcano.s
@@ -603,6 +603,7 @@ m_RivalWalksInFrontOfPlayer: .byte walk_left, look_down, end_m
 @ Jirachi events
 .global EventScript_CarnelidgeVolcano_Jirachi
 EventScript_CarnelidgeVolcano_Jirachi:
+    lock
     faceplayer
     cry SPECIES_JIRACHI 0x0
     msgbox gText_UltraSpace_Hoenn_FindingJirachi10 MSG_NORMAL

--- a/assembly/overworld_scripts/dungeons/daimyn_factory.s
+++ b/assembly/overworld_scripts/dungeons/daimyn_factory.s
@@ -105,6 +105,7 @@ EventScript_DaimynFactoryOverworld_FindTM93_Wild_Charge:
 
 .global EventScript_DaimynFactoryOverworld_ReminiscingOldMan
 EventScript_DaimynFactoryOverworld_ReminiscingOldMan:
+    lock
     checkflag 0x26E @ Steel beam tutor unlocked
     if SET _goto TeachSteelBeamQuestion
     npcchat gText_DaimynFactoryOverworld_ReminiscingOldMan
@@ -638,6 +639,7 @@ CloseLowerRightDoorB:
 
 .global EventScript_DaimynFactory_Meltan
 EventScript_DaimynFactory_Meltan:
+    lock
     faceplayer
     cry SPECIES_MELTAN 0x0
     waitcry

--- a/assembly/overworld_scripts/dungeons/empty_world.s
+++ b/assembly/overworld_scripts/dungeons/empty_world.s
@@ -899,6 +899,7 @@ EventScript_EmptyWorld_InterdimensionalResearchFacility_Sakura:
 
 .global EventScript_EmptyWorld_InterdimensionalResearchFacility_Rival
 EventScript_EmptyWorld_InterdimensionalResearchFacility_Rival:
+    lock
     faceplayer
     msgbox gText_EmptyWorld_InterdimensionalResearchFacility_Rival_AsksForPlayersHelp MSG_YESNO
     compare LASTRESULT NO

--- a/assembly/overworld_scripts/dungeons/forgotten_manse.s
+++ b/assembly/overworld_scripts/dungeons/forgotten_manse.s
@@ -194,6 +194,7 @@ EventScript_ForgottenManseExterior_BurglarChad:
 
 .global EventScript_ForgottenManseExterior_NurseLucy
 EventScript_ForgottenManseExterior_NurseLucy:
+    lock
     faceplayer
     checktrainerflag 0x57B
     if SET _goto NurseLucyHeal

--- a/assembly/overworld_scripts/dungeons/hesson_pass.s
+++ b/assembly/overworld_scripts/dungeons/hesson_pass.s
@@ -56,6 +56,7 @@ EventScript_HessonPass_CoolTrainerColt:
 
 .global EventScript_HessonPass_NurseMina
 EventScript_HessonPass_NurseMina:
+    lock
     faceplayer
     checktrainerflag 0x5D7
     if SET _goto NurseMinaHeal

--- a/assembly/overworld_scripts/dungeons/mimmett_jungle.s
+++ b/assembly/overworld_scripts/dungeons/mimmett_jungle.s
@@ -81,6 +81,7 @@ EventScript_MimmettJungle_PsychicWanda:
 
 .global EventScript_MimmettJungle_Zeraora
 EventScript_MimmettJungle_Zeraora:
+    lock
     msgbox gText_MimmettJungle_Zeraora_BattleConfirmation MSG_YESNO
     compare LASTRESULT NO
     if equal _goto ZeraoraChoseNo

--- a/assembly/overworld_scripts/dungeons/pluto_hq.s
+++ b/assembly/overworld_scripts/dungeons/pluto_hq.s
@@ -231,6 +231,7 @@ EventScript_PlutoHQ_B7F_TeamPlutoRichard:
 ## Irene's office
 .global EventScript_PlutoHQ_B4F_Irene
 EventScript_PlutoHQ_B4F_Irene:
+    lock
     faceplayer
     checkitem ITEM_SERPENT_KEY 0x1
     compare LASTRESULT TRUE
@@ -252,6 +253,7 @@ IreneDefeated:
 ## Ronald's office
 .global EventScript_PlutoHQ_B7F_Ronald
 EventScript_PlutoHQ_B7F_Ronald:
+    lock
     faceplayer
     checkitem ITEM_CERBERUS_KEY 0x1
     compare LASTRESULT TRUE

--- a/assembly/overworld_scripts/dungeons/rubarr_desert.s
+++ b/assembly/overworld_scripts/dungeons/rubarr_desert.s
@@ -57,6 +57,7 @@ MapResumeScript_HideGroudon:
 
 .global EventScript_RubarrDesert_NurseJaina
 EventScript_RubarrDesert_NurseJaina:
+    lock
     faceplayer
     checktrainerflag 0x517
     if SET _goto NurseJainaHeal
@@ -101,8 +102,8 @@ EventScript_RubarrDesert_TMFlameCharge:
 
 .global EventScript_RubarrDesert_CaveGuide
 EventScript_RubarrDesert_CaveGuide:
+    lockall
     faceplayer
-    lockall    
     msgbox gText_RubarrDesert_TourGuideIntro MSG_YESNO
     compare LASTRESULT YES
     if true _call EventScript_RubarrDesert_CaveGuide_Info

--- a/assembly/overworld_scripts/dungeons/scalding_spa.s
+++ b/assembly/overworld_scripts/dungeons/scalding_spa.s
@@ -37,6 +37,7 @@ SetNormalSnowfall:
 
 .global EventScript_ScaldingSpa_SpaRoom_PlutoGrunt
 EventScript_ScaldingSpa_SpaRoom_PlutoGrunt:
+    lock
     special 0xAF @ Dismount bike if on it
     playbgm 0x19A 0x1 @ Encounter Team Pluto (permanent, needs to be overidden to default track later)
     msgbox gtext_ScaldingSpa_SpaRoom_GruntShakesTheOldManDown MSG_NORMAL
@@ -288,6 +289,7 @@ EventScript_ScaldingSpa_BlackbeltKieran:
 
 .global EventScript_GlastrierRoom_Glastrier
 EventScript_GlastrierRoom_Glastrier:
+    lock
     faceplayer
     cry SPECIES_GLASTRIER 0x0
     waitcry

--- a/assembly/overworld_scripts/dungeons/ultra_space.s
+++ b/assembly/overworld_scripts/dungeons/ultra_space.s
@@ -174,6 +174,7 @@ EventScript_UltraSpace_EclipseVillage_BikeShop_Man:
 
 .global EventScript_UltraSpace_EclipseVillage_ReturnHomeResearcher
 EventScript_UltraSpace_EclipseVillage_ReturnHomeResearcher:
+    lock
     faceplayer
     msgbox gText_UltraSpace_Common_ResearcherGoHome MSG_YESNO
     compare LASTRESULT NO
@@ -189,6 +190,7 @@ PlayerChoseNotToGoHome:
 
 .global EventScript_UltraSpace_EclipseVillage_PoipoleResearcher
 EventScript_UltraSpace_EclipseVillage_PoipoleResearcher:
+    lock
     faceplayer
     checkflag 0x276 @ Received Poipole
     if SET _goto PlayerReceivedPoipoleAlready
@@ -600,6 +602,7 @@ EventScript_UltraSpaceHoenn_Wingull7:
     end
 
 WingullCommon:
+    lock
     faceplayer
     cry SPECIES_WINGULL 0x0
     msgbox gText_UltraSpace_Hoenn_Wingulls MSG_NORMAL

--- a/assembly/overworld_scripts/dungeons/victory_road.s
+++ b/assembly/overworld_scripts/dungeons/victory_road.s
@@ -313,6 +313,7 @@ EventScript_VictoryRoad_CoolTrainerDahlia:
 
 .global EventScript_VictoryRoad_NurseCelia
 EventScript_VictoryRoad_NurseCelia:
+    lock
     faceplayer
     checktrainerflag 510
     if SET _goto NurseCeliaHeal

--- a/assembly/overworld_scripts/routes/route_1-5.s
+++ b/assembly/overworld_scripts/routes/route_1-5.s
@@ -294,6 +294,7 @@ ReturningDexNavs:
     compareplayerfacing INTERNAL_RIGHT
     if equal _call MovePlayerBelowAssistantLeft
     waitmovement ALLEVENTS
+    lock
     faceplayer
     msgbox gText_Route3_AssistantWelcomesPlayerBack MSG_NORMAL
     showsprite Rival

--- a/assembly/overworld_scripts/routes/route_11-15.s
+++ b/assembly/overworld_scripts/routes/route_11-15.s
@@ -312,6 +312,7 @@ SignScript_Route11South_TrainerTips_MegaEvolution:
 
 .global EventScript_Route11South_Rival
 EventScript_Route11South_Rival:
+    lock
     faceplayer
     compare PlutoEncounterVar 0x4
     if equal _goto RivalBattlePrompt
@@ -458,6 +459,7 @@ DeniedRivalBattle:
 
 .global EventScript_Route11South_Alistair
 EventScript_Route11South_Alistair:
+    lock
     faceplayer
     compare PlutoEncounterVar 0x4
     if equal _goto AlistairBattleSupervision
@@ -786,6 +788,7 @@ PlayerDidNotAgreeToHelp:
 
 .global EventScript_Route11South_TeamPlutoClancy
 EventScript_Route11South_TeamPlutoClancy:
+    lock
     faceplayer
     playbgm 0x19A 0x1 @ Encounter Team Pluto (Permanent for the cutscene; player warps mean this doesn't need to be overridden again)
     setflag 0x926 @ Follower will move during active script
@@ -820,6 +823,7 @@ AlistairLookUp:
 
 .global EventScript_Route11South_TeamPlutoEna
 EventScript_Route11South_TeamPlutoEna:
+    lock
     faceplayer
     playbgm 0x19A 0x1 @ Encounter Team Pluto (Permanent for the cutscene; player warps mean this doesn't need to be overridden again)
     setflag 0x926 @ Follower will move during active script
@@ -938,6 +942,7 @@ MoveAlistairAndPlayerAfterClancyAndEna:
 
 .global EventScript_Route11SouthRefiner_RefinerShop
 EventScript_Route11SouthRefiner_RefinerShop:
+    lock
     faceplayer
     msgbox gText_Route11SouthHouse_RefinerShopWelcome MSG_NORMAL
     checkitem ITEM_RUSTED_DATA 0x1
@@ -1544,6 +1549,7 @@ EventScript_Route13_CollectorBenji:
 
 .global EventScript_Route13_Hiker_Left
 EventScript_Route13_Hiker_Left:
+    lock
     msgbox gText_Route13_HikerLeft MSG_NORMAL
     faceplayer
     npcchatwithmovement gText_Route13_HikerCommon m_LookRight
@@ -1551,6 +1557,7 @@ EventScript_Route13_Hiker_Left:
 
 .global EventScript_Route13_Hiker_Right
 EventScript_Route13_Hiker_Right:
+    lock
     msgbox gText_Route13_HikerRight MSG_NORMAL
     faceplayer
     npcchatwithmovement gText_Route13_HikerCommon m_LookLeft
@@ -1578,6 +1585,7 @@ EventScript_Route13_RestHouse_Hiker:
 
 .global EventScript_Route13_RestHouse_Merchant
 EventScript_Route13_RestHouse_Merchant:
+    lock
     faceplayer
     msgbox gText_Route13_RestHouse_Merchant MSG_YESNO
     compare LASTRESULT YES
@@ -1604,8 +1612,8 @@ RestHouseItems:
 
 .global EventScript_Route13_RestHouse_Nurse
 EventScript_Route13_RestHouse_Nurse:
-    faceplayer
     lock
+    faceplayer
     msgbox gText_Route13_RestHouse_Nurse MSG_NORMAL
     call PlayerHealNurse
     msgbox gText_Route13_RestHouse_NurseHealed MSG_NORMAL

--- a/assembly/overworld_scripts/routes/route_16-20.s
+++ b/assembly/overworld_scripts/routes/route_16-20.s
@@ -756,6 +756,7 @@ SignScript_Route18_OrichelleGarden:
 
 .global EventScript_Route18_ShayminFormChangeGirl
 EventScript_Route18_ShayminFormChangeGirl:
+    lock
     faceplayer
     checkflag 0x25A @ Gracidea given
     if SET _goto ExplainGracideaUsage
@@ -780,6 +781,7 @@ ExplainGracideaUsage:
 
 .global EventScript_Route18_RestWoman
 EventScript_Route18_RestWoman:
+    lock
     faceplayer
     msgbox gText_Route18_RestWoman_RestPrompt MSG_YESNO
     compare LASTRESULT YES
@@ -822,6 +824,7 @@ HideShaymin:
 
 .global EventScript_OrichelleGarden_Shaymin
 EventScript_OrichelleGarden_Shaymin:
+    lock
     faceplayer
     cry SPECIES_SHAYMIN 0x0
     waitcry
@@ -1097,6 +1100,7 @@ EventScript_Route20_JugglerHiram:
 
 .global EventScript_Route20_NurseJudy
 EventScript_Route20_NurseJudy:
+    lock
     faceplayer
     checktrainerflag 384
     if SET _goto NurseJudyHeal

--- a/assembly/overworld_scripts/routes/route_21-24.s
+++ b/assembly/overworld_scripts/routes/route_21-24.s
@@ -67,6 +67,7 @@ EventScript_Route21_RockerAxel:
 
 .global EventScript_Route21_VictoryRoadGuard
 EventScript_Route21_VictoryRoadGuard:
+    lock
     faceplayer
     msgbox gText_Route21_VictoryRoadGuard MSG_NORMAL
     checkflag 0x27F @ Registered for Victory Road challenge
@@ -101,6 +102,7 @@ PlayerMovesOutOfGuardsWay:
 
 .global EventScript_Route21_NurseBenedikta
 EventScript_Route21_NurseBenedikta:
+    lock
     faceplayer
     checktrainerflag 562
     if SET _goto NurseBenediktaHeal
@@ -320,6 +322,7 @@ SignScript_Route23_TrainerTips:
 
 .global EventScript_Route23_FishermansHouse_FishermanMaster
 EventScript_Route23_FishermansHouse_FishermanMaster:
+    lock
     faceplayer
     checkflag 0x24C @ Has Super Rod
     if SET _goto SuperRodExplaination
@@ -431,6 +434,7 @@ SignScript_Route24_TrainerTips:
 
 .global EventScript_Route24_House_DragonMaster
 EventScript_Route24_House_DragonMaster:
+    lock
     faceplayer
     msgbox gText_Route24_House_DragonMaster_Intro MSG_NORMAL
     callasm CountBadges

--- a/assembly/overworld_scripts/routes/route_6-10.s
+++ b/assembly/overworld_scripts/routes/route_6-10.s
@@ -55,6 +55,7 @@ EventScript_Route6_FishermanTaylor:
 
 .global EventScript_Route6_NurseLeanne
 EventScript_Route6_NurseLeanne:
+    lock
     faceplayer
     checktrainerflag 0x559
     if SET _goto NurseLeanneHeal
@@ -106,6 +107,7 @@ EventScript_Route6_SwimmerDanika:
 
 .global EventScript_Route6_SrAndJr_Sue
 EventScript_Route6_SrAndJr_Sue:
+    lock
     faceplayer
     trainerbattle0 0x0 0x60 0x0 gText_Route6_SrAndJrSueAndKat_Sue_Intro gText_Route6_SrAndJrSueAndKat_Sue_Defeat
     msgbox gText_Route6_SrAndJrSueAndKat_Sue_Chat MSG_NORMAL
@@ -113,6 +115,7 @@ EventScript_Route6_SrAndJr_Sue:
 
 .global EventScript_Route6_SrAndJr_Kat
 EventScript_Route6_SrAndJr_Kat:
+    lock
     faceplayer
     trainerbattle0 0x0 0x60 0x0 gText_Route6_SrAndJrSueAndKat_Kat_Intro gText_Route6_SrAndJrSueAndKat_Kat_Defeat
     msgbox gText_Route6_SrAndJrSueAndKat_Kat_Chat MSG_NORMAL
@@ -439,6 +442,7 @@ FishermanFarewell:
 @ Route 9
 .global EventScript_Route9_Flutist
 EventScript_Route9_Flutist:
+    lock
     faceplayer
     msgbox gText_Route9_FlutistShopIntroduction MSG_KEEPOPEN
     pokemart FluteShop
@@ -474,6 +478,7 @@ EventScript_Route9_TM66_Payback:
 
 .global EventScript_Route9_SlowbroGirl
 EventScript_Route9_SlowbroGirl:
+    lock
     msgbox gText_Route9_SlowbroGirlFrustration MSG_NORMAL
     faceplayer
     msgbox gText_Route9_SlowbroGirlApology MSG_NORMAL

--- a/assembly/overworld_scripts/towns/bruccie_village.s
+++ b/assembly/overworld_scripts/towns/bruccie_village.s
@@ -35,6 +35,7 @@ EventScript_BruccieVillage_Kid:
 
 .global EventScript_BruccieVillage_OldMan
 EventScript_BruccieVillage_OldMan:
+    lock
     checkflag 0xE18 @ Wingull event done
     if SET _goto OldMan_DailyEventDone
     faceplayer
@@ -121,6 +122,7 @@ EventScript_BruccieVillage_Wingull:
 
 .global EventScript_BruccieVillage_Abby
 EventScript_BruccieVillage_Abby:
+    lock
     faceplayer
     msgbox gText_BruccieVillage_Abby_Question MSG_YESNO
     compare LASTRESULT NO
@@ -289,6 +291,7 @@ GameboyKidsLookDown:
 
 .global EventScript_BruccieVillageFacilities_PokemonCenter_CaughtLocationGirl
 EventScript_BruccieVillageFacilities_PokemonCenter_CaughtLocationGirl:
+    lock
     faceplayer
     setvar 0x8003 0x0 @ From party
     setvar 0x8004 0x0 @ First slot
@@ -435,6 +438,7 @@ EventScript_BruccieVillageFacilities_Pokemart_StockBoy:
 @ NPC Houses
 .global EventScript_BruccieVillageNPCHouses_MoveTutor
 EventScript_BruccieVillageNPCHouses_MoveTutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
     buffernumber 0x0 0x8005 @ Take stored PokeChip count
@@ -465,6 +469,7 @@ NotEnoughPokeChips:
 
 .global EventScript_BruccieVillageNPCHouses_PokeballSwapper
 EventScript_BruccieVillageNPCHouses_PokeballSwapper:
+    lock
     faceplayer
     msgbox gText_BruccieVillageNPCHouses_PokeballSwapper_Intro MSG_NORMAL
     compare 0x409A 5
@@ -787,6 +792,7 @@ EventScript_BruccieVillageGym_Ellie:
 
 .global EventScript_BruccieVillageGym_Abby
 EventScript_BruccieVillageGym_Abby:
+    lock
     faceplayer
     checkflag 0x82C @ Game is cleared
     if SET _goto Abby_Postgame

--- a/assembly/overworld_scripts/towns/emraldin_quay.s
+++ b/assembly/overworld_scripts/towns/emraldin_quay.s
@@ -100,6 +100,7 @@ EventScript_EmraldinQuayNPCHouses_CamperMom:
 
 .global EventScript_EmraldinQuayNPCHouses_Tutor
 EventScript_EmraldinQuayNPCHouses_Tutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
     buffernumber 0x0 0x8005 @ Take stored PokeChip count
@@ -140,6 +141,7 @@ EventScript_EmraldinQuayNPCHouses_TutorYoungSon:
 
 .global EventScript_EmraldinQuayTrainerHouse_Host
 EventScript_EmraldinQuayTrainerHouse_Host:
+    lock
     faceplayer
     msgbox gText_EmraldinQuay_TrainerHouse_HostIntro MSG_NORMAL
     goto TrainerHouse_Menu
@@ -342,6 +344,7 @@ EventScript_EmraldinQuayTrainerHouse_FatGuy:
 
 .global EventScript_EmraldinQuayTrainerHouse_Girl
 EventScript_EmraldinQuayTrainerHouse_Girl:
+    lock
     faceplayer
     msgbox gText_EmraldinQuay_TrainerHouse_Girl MSG_YESNO
     compare LASTRESULT YES

--- a/assembly/overworld_scripts/towns/ferrox_village.s
+++ b/assembly/overworld_scripts/towns/ferrox_village.s
@@ -197,6 +197,7 @@ BerryGirlEnd:
 
 .global EventScript_FerroxNPCHouses_MoveTutor
 EventScript_FerroxNPCHouses_MoveTutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
 	buffernumber 0x0 0x8005 @ Take stored PokeChip count

--- a/assembly/overworld_scripts/towns/heleo_city.s
+++ b/assembly/overworld_scripts/towns/heleo_city.s
@@ -230,6 +230,7 @@ EventScript_HeleoFacilities_PokemonCenter_KidsMom:
 
 .global EventScript_HeleoFacilities_PokemonCenter_CriticalCapture
 EventScript_HeleoFacilities_PokemonCenter_CriticalCapture:
+    lock
     faceplayer
     msgbox gText_HeleoCityFacilities_CriticalCapture MSG_NORMAL
     checkitem ITEM_CATCHING_CHARM 0x1
@@ -563,6 +564,7 @@ EventScript_HeleoCity_ForemanAssistant:
 
 .global EventScript_HeleoCity_MoveTutor
 EventScript_HeleoCity_MoveTutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
 	buffernumber 0x0 0x8005 @ Take stored PokeChip count
@@ -1194,6 +1196,7 @@ SignScript_HeleoGym_PlacardWithBadge:
 
 .global EventScript_HeleoGym_Slowbro
 EventScript_HeleoGym_Slowbro:
+    lock
     faceplayer
     cry SPECIES_SLOWBRO 0x0
     applymovement LASTTALKED m_Question 

--- a/assembly/overworld_scripts/towns/laplaz_town.s
+++ b/assembly/overworld_scripts/towns/laplaz_town.s
@@ -23,6 +23,7 @@ EventScript_LaplazTown_Girl:
 
 .global EventScript_LaplazTown_OldMan
 EventScript_LaplazTown_OldMan:
+    lock
     faceplayer
     checkflag 0x03F @ Casey hidden in gym
     if SET _goto OldManNoGymLeader
@@ -102,6 +103,7 @@ EventScript_LaplazFacilities_GalarBirdsGirlsSister:
 
 .global EventScript_LaplazFacilities_Gentleman
 EventScript_LaplazFacilities_Gentleman:
+    lock
     checkitem ITEM_DECODER 0x1
     compare LASTRESULT TRUE
     if equal _goto DecoderGentleman_ExplainingDecoder
@@ -176,6 +178,7 @@ EventScript_LaplazFacilities_XItemsTip:
 
 .global EventScript_LaplazFacilities_TrainerHouse_Host
 EventScript_LaplazFacilities_TrainerHouse_Host:
+    lock
     faceplayer
     msgbox gText_LaplazFacilities_TrainerHouse_HostIntro MSG_NORMAL
     goto TrainerHouse_Menu
@@ -451,6 +454,7 @@ EventScript_LaplazNPCHouses_ApricornGrandpa:
 
 .global EventScript_LaplazNPCHouses_PsychicBrother
 EventScript_LaplazNPCHouses_PsychicBrother:
+    lock
     faceplayer
     checkflag 0x257 @ Got Hidden Power gift
     if SET _goto ExplainHiddenPower
@@ -469,6 +473,7 @@ ExplainHiddenPower:
 
 .global EventScript_LaplazNPCHouses_PsychicSister
 EventScript_LaplazNPCHouses_PsychicSister:
+    lock
     faceplayer
     checkflag 0x257 @ Got Hidden Power gift
     if NOT_SET _goto PlayerHasNotReceivedHiddenPower
@@ -513,6 +518,7 @@ ResetPsychicSister:
 
 .global EventScript_LaplazNPCHouses_ApricornSeller
 EventScript_LaplazNPCHouses_ApricornSeller:
+    lock
     faceplayer
     checkflag 0xE11 @ Apricorn ball bought today
     if SET _goto ApricornBallAlreadyBoughtToday
@@ -619,6 +625,7 @@ EventScript_LaplazNPCHouses_ApricornDescriber:
 
 .global EventScript_LaplazNPCHouses_Tutor
 EventScript_LaplazNPCHouses_Tutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
     buffernumber 0x0 0x8005 @ Take stored PokeChip count
@@ -891,6 +898,7 @@ RotateUp:
 
 .global EventScript_LaplazGym_LeaderCasey
 EventScript_LaplazGym_LeaderCasey:
+    lock
     faceplayer
     call SetCaseyGender
     checkflag 0x82C @ Game is cleared

--- a/assembly/overworld_scripts/towns/rhodanzi_city.s
+++ b/assembly/overworld_scripts/towns/rhodanzi_city.s
@@ -432,6 +432,7 @@ EventScript_RhodanziTrainerSchool_MainRoom_Professor:
 
 .global EventScript_RhodanziTrainerSchool_TerrainTutor
 EventScript_RhodanziTrainerSchool_TerrainTutor:
+    lock
     faceplayer
     msgbox gText_RhodanziTrainerSchool_MainRoom_TerrainTutor_Intro MSG_NORMAL
     checkflag 0x820 @ Has Terrain Badge

--- a/assembly/overworld_scripts/towns/tsarvosa_city.s
+++ b/assembly/overworld_scripts/towns/tsarvosa_city.s
@@ -108,6 +108,7 @@ SignScript_TsarvosaCity_GymTraineesCafeSign:
 
 .global EventScript_TsarvosaCity_DaimynFactoryPresident
 EventScript_TsarvosaCity_DaimynFactoryPresident:
+    lock
     faceplayer
     checkitem ITEM_FACTORY_KEY 0x1
     compare LASTRESULT TRUE
@@ -216,6 +217,7 @@ EventScript_TsarvosaCity_StatsDojo_Attendant:
 
 .global EventScript_TsarvosaCity_StatsDojo_Kaito
 EventScript_TsarvosaCity_StatsDojo_Kaito:
+    lock
     faceplayer
     checktrainerflag 406
     if SET _goto KaitoWelcomesPlayer
@@ -1115,8 +1117,8 @@ EventScript_TsarvosaCity_StatsDojo_SpeedDisciple:
     end
 
 EVDiscipleCommon:
-    faceplayer
     lock
+    faceplayer
     msgbox gText_TsarvosaCity_StatsDojo_EVDiscipleIntro MSG_NORMAL
     checktrainerflag 406
     if NOT_SET _goto FacilitiesCannotOfferServices
@@ -1206,6 +1208,7 @@ m_CameraMovesUp: .byte walk_up, walk_up, walk_up, end_m
 @ NPC Houses
 .global EventScript_TsarvosaCity_NPCHouses_MoveTutor
 EventScript_TsarvosaCity_NPCHouses_MoveTutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
     buffernumber 0x0 0x8005 @ Take stored PokeChip count
@@ -1287,6 +1290,7 @@ EventScript_TsarvosaCity_NPCHouses_SlowbroGTradeMother:
 
 .global EventScript_TsarvosaCity_NPCHouses_DevTeamCollin
 EventScript_TsarvosaCity_NPCHouses_DevTeamCollin:
+    lock
     faceplayer
     msgbox gText_TsarvosaCityNPCHouses_DevTeam_CollinIntro MSG_NORMAL
     checkflag 0xE1D @ Battled Collin today
@@ -1332,6 +1336,7 @@ CollinClosingStatement:
 
 .global EventScript_TsarvosaCity_NPCHouses_DevTeamCrystal
 EventScript_TsarvosaCity_NPCHouses_DevTeamCrystal:
+    lock
     faceplayer
     msgbox gText_TsarvosaCityNPCHouses_DevTeam_CrystalIntro MSG_NORMAL
     checkflag 0xE1E @ Battled Crystal today
@@ -2140,6 +2145,7 @@ m_CafeAttendnatReturnsToPosition: .byte walk_up, walk_up, look_down, end_m
 
 .global EventScript_TsarvosaCity_NPCHouses_PokeChipCrusher
 EventScript_TsarvosaCity_NPCHouses_PokeChipCrusher:
+    lock
     faceplayer
     msgbox gText_TsarvosaCity_NPCHouses_PokeCrusherIntro MSG_KEEPOPEN
     setvar 0x8000 0xE @ Pokechip crusher
@@ -2368,6 +2374,7 @@ EventScript_TsarvosaCity_NPCHouses_IrisAndStellaGrandpa:
 
 .global EventScript_TsarvosaCity_NPCHouses_IrisFanClubPresident
 EventScript_TsarvosaCity_NPCHouses_IrisFanClubPresident:
+    lock
     faceplayer
     checkflag 0x261 @ Received Flame Orb
     if SET _goto ReceivedFlameOrb
@@ -2674,6 +2681,7 @@ HeldItemsShop4:
 
 .global EventScript_TsarvosaCity_Gym_LeaderIris
 EventScript_TsarvosaCity_Gym_LeaderIris:
+    lock
     faceplayer
     checkflag 0x82C @ Game is cleared
     if SET _goto Iris_Postgame

--- a/assembly/overworld_scripts/towns/uteya_village.s
+++ b/assembly/overworld_scripts/towns/uteya_village.s
@@ -170,6 +170,7 @@ EventScript_UteyaVillage_Pokemart_OldWoman:
 
 .global EventScript_UteyaVillage_MoveTutor
 EventScript_UteyaVillage_MoveTutor:
+    lock
     faceplayer
     callasm StorePokeChipCount
     buffernumber 0x0 0x8005 @ Take stored PokeChip count
@@ -222,6 +223,7 @@ BufferSpeciesName:
 
 .global EventScript_UteyaVillage_SlowpokeNews_Producer
 EventScript_UteyaVillage_SlowpokeNews_Producer:
+    lock
     checkflag 0xE33 @ Slowpoke News completed today
     if SET _goto SlowpokeNewsCompleted_Producer
     faceplayer
@@ -366,6 +368,7 @@ LevelScript_MeetingClancyAndEnaInTheirHome:
 
 .global EventScript_UteyaVillage_Clancy
 EventScript_UteyaVillage_Clancy:
+    lock
     faceplayer
     callasm StorePokeChipCount
     buffernumber 0x0 0x8005 @ Take stored PokeChip count
@@ -573,6 +576,7 @@ m_ClancyReturnsToSeat: .byte walk_up, walk_up, look_left, end_m
 // Trainer House
 .global EventScript_UteyaVillage_TrainerHouse_Host
 EventScript_UteyaVillage_TrainerHouse_Host:
+    lock
     faceplayer
     msgbox gText_UteyaVillage_TrainerHouse_HostIntro MSG_NORMAL
     goto TrainerHouse_Menu
@@ -761,6 +765,7 @@ Trainerhouse_grandprize:
 
 .global EventScript_UteyaVillage_TrainerHouse_Man
 EventScript_UteyaVillage_TrainerHouse_Man:
+    lock
     msgbox gText_UteyaVillage_TrainerHouse_Man MSG_NORMAL
     faceplayer
     npcchatwithmovement gText_UteyaVillage_TrainerHouse_ManAfterFacingPlayer m_LookUp
@@ -939,6 +944,7 @@ MoveCopyCatToPuzzle:
 @ and also have a movment value up to FF (15x15 movement grid). If it is 00 they'll have a default radius of 3! 
 .global EventScript_UteyaVillage_Gym_Copycat
 EventScript_UteyaVillage_Gym_Copycat:
+    lock
     faceplayer
     call SetCopyCatGender
     msgbox gText_UteyaVillage_Gym_Copycat_AskPlayerWhatTheyNeed MSG_YESNO
@@ -1277,6 +1283,7 @@ EventScript_UteyaVillage_Gym_Clarice:
 
 .global EventScript_UteyaVillage_Gym_LeaderDennis
 EventScript_UteyaVillage_Gym_LeaderDennis:
+    lock
     faceplayer
     checkflag 0x82C @ Game is cleared
     if SET _goto Dennis_Postgame
@@ -1299,6 +1306,7 @@ EventScript_UteyaVillage_Gym_LeaderDennis:
 
 .global EventScript_UteyaVillage_Gym_LeaderDee
 EventScript_UteyaVillage_Gym_LeaderDee:
+    lock
     faceplayer
     checkflag 0x82C @ Game is cleared
     if SET _goto Dee_Postgame


### PR DESCRIPTION
Add all missing `lock` statements before `faceplayer` commands.  This is not needed for any events using `npcchat` or `npcchatwithmovement` because they call `lock` as part of their asm definitions.

This logic change ensures the player stops their running/walking animation when interacting with these events