### PR TITLE
Relocate CFRU in the rom to make room for more items

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -1,7 +1,7 @@
 OUTPUT_ARCH(arm)
 MEMORY {
 
-		rom     : ORIGIN = (0x08000000 + 0x810000), LENGTH = 32M
+		rom     : ORIGIN = (0x08000000 + 0x820000), LENGTH = 32M
         ewram   : ORIGIN = 0x02000000, LENGTH = 4M - 4k
 }
 

--- a/scripts/insert.py
+++ b/scripts/insert.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 import _io
 
-OFFSET_TO_PUT = 0x810000
+OFFSET_TO_PUT = 0x820000
 SOURCE_ROM = "BPRE0.gba"
 ROM_NAME = "test.gba"
 

--- a/scripts/make.py
+++ b/scripts/make.py
@@ -9,7 +9,7 @@ import sys
 ############
 
 ROM_NAME = "BPRE0.gba"  # The name of your rom
-OFFSET_TO_PUT = 0x810000
+OFFSET_TO_PUT = 0x820000
 SEARCH_FREE_SPACE = False  # Set to True if you want the script to search for free space
                            # Set to False if you don't want to search for free space as you for example update the engine
 


### PR DESCRIPTION
Relocate CFRU in the rom to make room for more item data.

By default, HMA adds a buffer around repointed data to account for it's maximum potential size (e.x. descriptions). This repointed data can be manually moved, but...

We have so much free room in the ROM around CFRU that it doesn't matter. We can just move CFRU's engine updates.