### PR TITLE
Disable door/window pal fading

### DIFF
--- a/include/new/dns_data.h
+++ b/include/new/dns_data.h
@@ -252,39 +252,39 @@ const struct DNSPalFade gDNSNightFadingByTime[24][6] =
 const struct SpecificTilesetFade gSpecificTilesetFades[] =
 {
 	//These Palette Town ones have been left in as examples. Feel free to remove.
-	{ //Palette Town - Player's Door
-		.tilesetPointer = 0x82D4AAC, //Tileset 1
-		.paletteNumToFade = 8,
-		.paletteIndicesToFade =
-		{
-			{8,  RGB(31, 31, 20)},
-			{9,  RGB(31, 31, 11)},
-			{10, RGB(31, 31, 10)},
-			TILESET_PAL_FADE_END
-		},
-	},
-	{ //Palette Town - Oak's Lab Windows
-		.tilesetPointer = 0x82D4AAC, //Tileset 1
-		.paletteNumToFade = 9,
-		.paletteIndicesToFade =
-		{
-			{8,  RGB(31, 31, 20)},
-			{9,  RGB(31, 31, 14)},
-			{10, RGB(31, 30, 0)},
-			TILESET_PAL_FADE_END
-		},
-	},
-	{ //Palette Town - Oak's Lab Door
-		.tilesetPointer = 0x82D4AAC, //Tileset 1
-		.paletteNumToFade = 10,
-		.paletteIndicesToFade =
-		{
-			{8,  RGB(31, 31, 20)},
-			{9,  RGB(31, 31, 14)},
-			{10, RGB(31, 30, 0)},
-			TILESET_PAL_FADE_END
-		},
-	},
+	// { //Palette Town - Player's Door
+	// 	.tilesetPointer = 0x82D4AAC, //Tileset 1
+	// 	.paletteNumToFade = 8,
+	// 	.paletteIndicesToFade =
+	// 	{
+	// 		{8,  RGB(31, 31, 20)},
+	// 		{9,  RGB(31, 31, 11)},
+	// 		{10, RGB(31, 31, 10)},
+	// 		TILESET_PAL_FADE_END
+	// 	},
+	// },
+	// { //Palette Town - Oak's Lab Windows
+	// 	.tilesetPointer = 0x82D4AAC, //Tileset 1
+	// 	.paletteNumToFade = 9,
+	// 	.paletteIndicesToFade =
+	// 	{
+	// 		{8,  RGB(31, 31, 20)},
+	// 		{9,  RGB(31, 31, 14)},
+	// 		{10, RGB(31, 30, 0)},
+	// 		TILESET_PAL_FADE_END
+	// 	},
+	// },
+	// { //Palette Town - Oak's Lab Door
+	// 	.tilesetPointer = 0x82D4AAC, //Tileset 1
+	// 	.paletteNumToFade = 10,
+	// 	.paletteIndicesToFade =
+	// 	{
+	// 		{8,  RGB(31, 31, 20)},
+	// 		{9,  RGB(31, 31, 14)},
+	// 		{10, RGB(31, 30, 0)},
+	// 		TILESET_PAL_FADE_END
+	// 	},
+	// },
 };
 
 #else //For Pokemon Unbound - Feel free to remove


### PR DESCRIPTION
Disable door/window palette fading at night in Anthra and Olenic Towns. This was a nice feature, but would require too many technical challenges to be solved to apply everywhere, so consistency was favoured.

Specifically, many door/window palettes outside of these locations share palettes with roofs, ponds, etc. leading to some very undesirable palette fading.