### PR TITLE
Update Ascension Tower Board

### DIFF
--- a/assembly/overworld_scripts/daimyn_city/ascension_tower.s
+++ b/assembly/overworld_scripts/daimyn_city/ascension_tower.s
@@ -126,27 +126,29 @@ OpenFloorBarrier:
 .global EventScript_AscensionTower_BattleTowerAttendant
 EventScript_AscensionTower_BattleTowerAttendant:
     lock
-    msgbox gText_AscensionTower_BattleTowerAttendant_Introduction MSG_KEEPOPEN
-    multichoiceoption gText_Yes 0
-	multichoiceoption gText_Info 1
-	multichoiceoption gText_No 2
-    multichoice 0x0 0x0 THREE_MULTICHOICE_OPTIONS FALSE
-	copyvar MULTICHOICE_SELECTION LASTRESULT
-	switch LASTRESULT
-	case 0, TakeBattleTowerChallenge
-	case 1, BattleTowerInfo
-	case 2, AttendantChoseNo
-    goto AttendantChoseNo
-
-TakeBattleTowerChallenge:
-    @ Later, perform a check here for the champions flag
-    msgbox gText_AscensionTower_BattleTowerAttendant_NotChampion MSG_NORMAL
-    release
+    msgbox gText_AscensionTower_BattleTowerAttendant_GatheringFunding MSG_NORMAL
     end
+    @ msgbox gText_AscensionTower_BattleTowerAttendant_Introduction MSG_KEEPOPEN
+    @ multichoiceoption gText_Yes 0
+	@ multichoiceoption gText_Info 1
+	@ multichoiceoption gText_No 2
+    @ multichoice 0x0 0x0 THREE_MULTICHOICE_OPTIONS FALSE
+	@ copyvar MULTICHOICE_SELECTION LASTRESULT
+	@ switch LASTRESULT
+	@ case 0, TakeBattleTowerChallenge
+	@ case 1, BattleTowerInfo
+	@ case 2, AttendantChoseNo
+    @ goto AttendantChoseNo
 
-BattleTowerInfo:
-    msgbox gText_AscensionTower_EliteFourAttendant_BattleTowerInfo MSG_NORMAL
-    goto EventScript_AscensionTower_BattleTowerAttendant
+@ TakeBattleTowerChallenge:
+@     @ Later, perform a check here for the champions flag
+@     msgbox gText_AscensionTower_BattleTowerAttendant_NotChampion MSG_NORMAL
+@     release
+@     end
+
+@ BattleTowerInfo:
+@     msgbox gText_AscensionTower_EliteFourAttendant_BattleTowerInfo MSG_NORMAL
+@     goto EventScript_AscensionTower_BattleTowerAttendant
 
 .global EventScript_AscensionTower_EliteFourAttendant
 EventScript_AscensionTower_EliteFourAttendant:
@@ -256,7 +258,11 @@ SignScript_AscensionTower_RecordsBoard:
     end
 
 RecordsBoard_PostChampion:
-    @ TODO: Populate later. Should track # of times player has defended their title and battle tower records
+    setvar 0x8004 10 @ Times entered the hall of fame
+    callasm StoreGameStat
+    subvar LASTRESULT 0x1 @ First time is entry into the hall of fame
+    buffernumber 0x0 LASTRESULT
+    msgbox gText_AscensionTower_RecordsSign_ChampionTitleDefenses MSG_SIGN
     end
 
 m_PlayerWalksToRival: .byte walk_up, walk_up, walk_right, walk_right, walk_up, walk_up, look_right, end_m

--- a/strings/scripts/towns/daimyn_city.string
+++ b/strings/scripts/towns/daimyn_city.string
@@ -1291,6 +1291,9 @@ Wonderful! Please, allow me to get\nthe gate for you.
 #org @gText_AscensionTower_EliteFourAttendant_WishingLuck
 You may proceed to the elevator at\nthe back of the room.\pIt will take you to your first\nchallenge.\pShould you succeed, you may return\nto the elevator to be\ldelievered to your next challenge.\pOn behalf of everyone at Ascension\nTower, I wish you the best of\lluck!
 
+#org @gText_AscensionTower_BattleTowerAttendant_GatheringFunding
+Welcome to Ascension Tower!\pI would normally be accepting\nregistrations for the Battle\lFrontier.\pWe're currently undergoing some\nmaintenance, however[.]\pWe can hopefully offer this service\nsomeday soon.\pUntil then, please continue to train\nyour Pok\emon and strive to be the\lbest you can be.
+
 #org @gText_AscensionTower_BattleTowerAttendant_Introduction
 Welcome to Ascension Tower! I accept\nregistrations for the Battle Tower\lChallenge.\pWould you like to take the Battle\nTower Challenge?
 
@@ -1313,7 +1316,10 @@ I like coming here to watch the\nElite Four challengers battle!\pEveryone gives 
 My son dreams of becoming the\nChampion. It's all he talks about.\pI thought I'd come here to see what\nit's all about.\pThis Champion is seriously strong! I'd\nbetter help him train so he can do\lhis best.
 
 #org @gText_AscensionTower_RecordsSign
-It's a board showing the records\nof all the trainers who've\lchallenged the Elite Four and\lBattle Tower.
+It's a board showing the records\nof all the trainers who've\lchallenged the Elite Four.
+
+#org @gText_AscensionTower_RecordsSign_ChampionTitleDefenses
+I've defended my Champion title\n[BUFFER1] times!\pI wonder if I can set a record?
 
 #org @gText_AscensionTower_RecordsSign_NotOnBoard
 Maybe someday I'll be on here!


### PR DESCRIPTION
Update the Ascension Tower notice board to count the number of times the player has defended their title.
This also removes Battle Tower text, until it is ready to be implemented.